### PR TITLE
Add back `.by`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,8 @@ Imports:
     rlang (>= 0.1.2),
     stringr,
     tibble,
-    tidyr (>= 1.2.0)
+    tidyr (>= 1.2.0),
+    vctrs
 Suggests:
     covr,
     mockery,

--- a/R/bart.R
+++ b/R/bart.R
@@ -5,15 +5,16 @@
 #'
 #' @template common
 #' @template options
-#' @return A [tibble][tibble::tibble-package] contains following values:
+#' @return An object with the same class as `data` contains following values:
 #'   \item{mean_pumps}{Mean of hits for balloons not exploded.}
 #'   \item{mean_pumps_raw}{Mean of hits for all balloons.}
 #'   \item{num_explosion}{Number of exploded balloons.}
 #' @export
-bart <- function(data, .input = NULL, .extra = NULL) {
+bart <- function(data, .by = NULL, .input = NULL, .extra = NULL) {
   .input <- list(name_feedback = "feedback", name_nhit = "nhit") |>
     update_settings(.input)
   data |>
+    group_by(across(all_of(.by))) |>
     summarise(
       mean_pumps = .data[[.input$name_nhit]] |>
         # keep not exploded trials only
@@ -22,5 +23,6 @@ bart <- function(data, .input = NULL, .extra = NULL) {
       mean_pumps_raw = mean(.data[[.input$name_nhit]]),
       num_explosion = sum(.data[[.input$name_feedback]] == 0),
       .groups = "drop"
-    )
+    ) |>
+    vctrs::vec_restore(data)
 }

--- a/R/bps.R
+++ b/R/bps.R
@@ -5,14 +5,14 @@
 #'
 #' @template common
 #' @template options
-#' @return A [tibble][tibble::tibble-package] contains following values:
+#' @return An object with the same class as `data` contains following values:
 #'   \item{pc}{Percent of correct responses.}
 #'   \item{p_sim_foil}{Percent of similar responses for "foil" stimuli.}
 #'   \item{p_sim_lure}{Percent of similar responses for "lure" stimuli.}
 #'   \item{p_sim_target}{Percent of similar responses for "target" stimuli.}
 #'   \item{bps_score}{BPS score.}
 #' @export
-bps <- function(data, .input = NULL, .extra = NULL) {
+bps <- function(data, .by = NULL, .input = NULL, .extra = NULL) {
   .input <- list(
     name_phase = "phase",
     name_acc = "acc",
@@ -25,16 +25,17 @@ bps <- function(data, .input = NULL, .extra = NULL) {
     resp_sim = "similar"
   ) |>
     update_settings(.extra)
-  data_cor <- data |>
+  data_test_phase <- data |>
     filter(.data[[.input$name_phase]] == .extra$phase_test)
-  bind_cols(
-    data_cor |>
+  merge(
+    data_test_phase |>
+      group_by(across(all_of(.by))) |>
       summarise(
         pc = mean(.data[[.input$name_acc]] == 1),
         .groups = "drop"
       ),
-    data_cor |>
-      group_by(.data[[.input$name_type]]) |>
+    data_test_phase |>
+      group_by(across(all_of(c(.by, .input$name_type)))) |>
       summarise(
         p_sim = mean(.data[[.input$name_resp]] == .extra$resp_sim),
         .groups = "drop"
@@ -44,6 +45,8 @@ bps <- function(data, .input = NULL, .extra = NULL) {
         names_prefix = "p_sim_",
         values_from = "p_sim"
       ) |>
-      mutate(bps_score = .data$p_sim_lure - .data$p_sim_foil)
-  )
+      mutate(bps_score = .data$p_sim_lure - .data$p_sim_foil),
+    by = .by
+  ) |>
+    vctrs::vec_restore(data)
 }

--- a/R/cpt.R
+++ b/R/cpt.R
@@ -6,9 +6,9 @@
 #'
 #' @template common
 #' @template options
-#' @return A [tibble][tibble::tibble-package] contains following values:
+#' @return An object with the same class as `data` contains following values:
 #'
-#'   \item{nc}{Count of correct responses.}
+#'   \item{pc}{Percent of correct responses.}
 #'
 #'   \item{mrt}{Mean reaction time of hits.}
 #'
@@ -16,19 +16,11 @@
 #'
 #'   \item{dprime}{Sensitivity (d').}
 #'
-#'   \item{c}{Bias index.}
-#'
-#'   \item{ies}{Inverse efficiency score.}
-#'
-#'   \item{rcs}{Rate correct score.}
-#'
-#'   \item{lisas}{Linear integrated speed-accuracy score.}
-#'
 #'   \item{commissions}{Number of errors caused by action.}
 #'
 #'   \item{omissions}{Number of errors caused by inaction.}
 #' @export
-cpt <- function(data, .input = NULL, .extra = NULL) {
+cpt <- function(data, .by = NULL, .input = NULL, .extra = NULL) {
   .input <- list(name_acc = "acc", name_type = "type", name_rt = "rt") |>
     update_settings(.input)
   .extra <- list(type_signal = "target") |>
@@ -45,17 +37,29 @@ cpt <- function(data, .input = NULL, .extra = NULL) {
       # remove rt from non-signal trials
       rt_cor = ifelse(.data$type_cor == "s", .data[[.input$name_rt]], NA)
     )
-  bind_cols(
+  merge(
     calc_spd_acc(
       data_cor,
+      by = .by,
       name_acc = .input$name_acc,
-      name_rt = "rt_cor",
-      acc_rtn = "count"
+      name_rt = "rt_cor"
     ),
     calc_sdt(
       data_cor,
+      by = .by,
       name_acc = .input$name_acc,
       name_type = "type_cor"
-    )
-  )
+    ),
+    by = .by
+  ) |>
+    select(
+      all_of(
+        c(
+          .by,
+          "pc", "mrt", "rtsd",
+          "dprime", "commissions", "omissions"
+        )
+      )
+    ) |>
+    vctrs::vec_restore(data)
 }

--- a/R/driving.R
+++ b/R/driving.R
@@ -4,10 +4,10 @@
 #'
 #' @template common
 #' @template options
-#' @return A [tibble][tibble::tibble-package] contains following values:
+#' @return An object with the same class as `data` contains following values:
 #'   \item{still_ratio}{The ratio of still duration in yellow light state.}
 #' @export
-driving <- function(data, .input = NULL, .extra = NULL) {
+driving <- function(data, .by = NULL, .input = NULL, .extra = NULL) {
   .input <- list(
     name_still_dur = "stilldur",
     name_still_light = "stilllight",
@@ -32,9 +32,11 @@ driving <- function(data, .input = NULL, .extra = NULL) {
         )
       )
     ) |>
+    group_by(across(all_of(.by))) |>
     summarise(
       still_ratio = sum(.data$still_dur_yellow) /
         sum(.data[[.input$name_yellow_dur]]),
       .groups = "drop"
-    )
+    ) |>
+    vctrs::vec_restore(data)
 }

--- a/R/igt.R
+++ b/R/igt.R
@@ -6,21 +6,25 @@
 #'
 #' @template common
 #' @template options
-#' @return A [tibble][tibble::tibble-package] contains following values:
+#' @return An object with the same class as `data` contains following values:
+#'
 #'   \item{sum_outcome}{The total outcome over all trials.}
+#'
 #'   \item{perc_good}{The number of choices on "good" pools.}
 #' @export
-igt <- function(data, .input = NULL, .extra = NULL) {
+igt <- function(data, .by = NULL, .input = NULL, .extra = NULL) {
   .input <- list(name_outcome = "outcome", name_pool = "poolid") |>
     update_settings(.input)
   .extra <- list(pools_advantage = c("a", "b")) |>
     update_settings(.extra)
   data |>
+    group_by(across(all_of(.by))) |>
     summarise(
       sum_outcome = sum(.data[[.input$name_outcome]]),
       perc_good = mean(
         .data[[.input$name_pool]] %in% .extra$pools_advantage
       ),
       .groups = "drop"
-    )
+    ) |>
+    vctrs::vec_restore(data)
 }

--- a/R/jlo.R
+++ b/R/jlo.R
@@ -5,13 +5,16 @@
 #'
 #' @template common
 #' @template options
-#' @return A [tibble][tibble::tibble-package] contains following values:
+#' @return An object with the same class as `data` contains following values:
+#'
 #'   \item{nc}{Count of correct responses.}
+#'
 #'   \item{mean_ang_err}{Mean of the response angle errors.}
+#'
 #'   \item{mean_log_err}{Mean of the log-transformed (of base 2) response angle
 #'     errors.}
 #' @export
-jlo <- function(data, .input = NULL, .extra = NULL) {
+jlo <- function(data, .by = NULL, .input = NULL, .extra = NULL) {
   .input <- list(name_resp = "resp", name_angle = "angle", name_acc = "acc") |>
     update_settings(.input)
   .extra <- list(resp_anticlock = "left", resp_clockwise = "right") |>
@@ -37,10 +40,13 @@ jlo <- function(data, .input = NULL, .extra = NULL) {
         .data$resp_err_raw
       )
     ) |>
+    group_by(across(all_of(.by))) |>
     summarise(
       nc = sum(.data[[.input$name_acc]] == 1),
       mean_ang_err = mean(.data$resp_err),
       # make sure it is between 0 and 1
-      mean_log_err = mean(log2(.data$resp_err / 90 + 1))
-    )
+      mean_log_err = mean(log2(.data$resp_err / 90 + 1)),
+      .groups = "drop"
+    ) |>
+    vctrs::vec_restore(data)
 }

--- a/R/locmem.R
+++ b/R/locmem.R
@@ -7,15 +7,19 @@
 #'
 #' @template common
 #' @template options
-#' @return A [tibble][tibble::tibble-package] contains following values:
+#' @return An object with the same class as `data` contains following values:
+#'
 #'   \item{nc_loc}{Count of correct responses for location.}
+#'
 #'   \item{mean_dist_err}{Mean of the response distance errors.}
+#'
 #'   \item{mean_log_err}{Mean of the log-transformed (of base \eqn{e}) response
-#'     distance errors.}
+#'   distance errors.}
+#'
 #'   \item{nc_order}{Count of correct responses for order. For [locmem2()]
-#'     only.}
+#'   only.}
 #' @export
-locmem <- function(data, .input = NULL, .extra = NULL) {
+locmem <- function(data, .by = NULL, .input = NULL, .extra = NULL) {
   .input <- list(name_dist = "resplocdist") |>
     update_settings(.input)
   data |>
@@ -24,30 +28,38 @@ locmem <- function(data, .input = NULL, .extra = NULL) {
       .keep = "unused"
     ) |>
     unnest(.data$dist) |>
+    group_by(across(all_of(.by))) |>
     summarise(
       nc_loc = sum(.data$dist == 0),
       mean_dist_err = mean(.data$dist),
       mean_log_err = mean(log(.data$dist + 1)),
       .groups = "drop"
-    )
+    ) |>
+    vctrs::vec_restore(data)
 }
 
 #' @rdname locmem
 #' @export
-locmem2 <- function(data, .input = NULL, .extra = NULL) {
-  .input <- list(name_acc_order = "respaccorder") |>
+locmem2 <- function(data, .by = NULL, .input = NULL, .extra = NULL) {
+  .input <- list(
+    name_dist = "resplocdist",
+    name_acc_order = "respaccorder"
+  ) |>
     update_settings(.input)
-  bind_cols(
-    locmem(data, .input, .extra),
+  merge(
+    locmem(data, .by, .input, .extra),
     data |>
       mutate(
         acc_order = parse_char_resp(.data[[.input$name_acc_order]]),
         .keep = "unused"
       ) |>
       unnest(.data$acc_order) |>
+      group_by(across(all_of(.by))) |>
       summarise(
         nc_order = sum(.data$acc_order == 1),
         .groups = "drop"
-      )
-  )
+      ),
+    by = .by
+  ) |>
+    vctrs::vec_restore(data)
 }

--- a/R/multisense.R
+++ b/R/multisense.R
@@ -5,14 +5,18 @@
 #'
 #' @template common
 #' @template options
-#' @return A [tibble][tibble::tibble-package] contains following values:
+#' @return An object with the same class as `data` contains following values:
+#'
 #'   \item{mrt_image}{Mean reaction time of Image stimuli.}
+#'
 #'   \item{mrt_sound}{Mean reaction time of Sound stimuli.}
+#'
 #'   \item{mrt_mixed}{Mean reaction time of Mixed stimuli.}
+#'
 #'   \item{mrt_mixadv}{Mean reaction decrease of Mixed stimuli compared to other
 #'     two types of stimuli.}
 #' @export
-multisense <- function(data, .input = NULL, .extra = NULL) {
+multisense <- function(data, .by = NULL, .input = NULL, .extra = NULL) {
   .input <- list(name_type = "type", name_rt = "rt") |>
     update_settings(.input)
   .extra <- list(
@@ -23,19 +27,13 @@ multisense <- function(data, .input = NULL, .extra = NULL) {
     update_settings(.extra)
   data |>
     mutate(acc_dummy = 1) |>
-    group_by(.data[[.input$name_type]]) |>
-    group_modify(
-      ~ calc_spd_acc(
-        .x,
-        name_acc = "acc_dummy",
-        name_rt = .input$name_rt,
-        rt_rtn = "mean",
-        acc_rtn = "none",
-        sat_rtn = "none"
-      )
+    calc_spd_acc(
+      by = c(.by, .input$name_type),
+      name_acc = "acc_dummy",
+      name_rt = .input$name_rt
     ) |>
-    # `pivot_wider` will drop groups here because groups go to columns
     pivot_wider(
+      id_cols = all_of(.by),
       names_from = .input$name_type,
       names_prefix = "mrt_",
       values_from = "mrt"

--- a/R/nle.R
+++ b/R/nle.R
@@ -4,11 +4,13 @@
 #'
 #' @template common
 #' @template options
-#' @return A [tibble][tibble::tibble-package] contains following values:
+#' @return An object with the same class as `data` contains following values:
+#'
 #'   \item{mean_abs_err}{Mean absolute error.}
+#'
 #'   \item{mean_log_err}{Mean log absolute error.}
 #' @export
-nle <- function(data, .input = NULL, .extra = NULL) {
+nle <- function(data, .by = NULL, .input = NULL, .extra = NULL) {
   .input <- list(name_number = "number", name_resp = "resp") |>
     update_settings(.input)
   data |>
@@ -16,8 +18,11 @@ nle <- function(data, .input = NULL, .extra = NULL) {
       err = abs(.data[[.input$name_number]] -
         .data[[.input$name_resp]])
     ) |>
+    group_by(across(all_of(.by))) |>
     summarise(
       mean_abs_err = mean(.data$err),
-      mean_log_err = mean(log(.data$err + 1))
-    )
+      mean_log_err = mean(log(.data$err + 1)),
+      .groups = "drop"
+    ) |>
+    vctrs::vec_restore(data)
 }

--- a/R/nsymncmp.R
+++ b/R/nsymncmp.R
@@ -4,13 +4,16 @@
 #'
 #' @template common
 #' @template options
-#' @return A [tibble][tibble::tibble-package] contains following values:
+#' @return An object with the same class as `data` contains following values:
+#'
 #'   \item{pc}{Percentage of correct responses.}
+#'
 #'   \item{mrt}{Mean reaction time.}
+#'
 #'   \item{w}{Weber fraction.}
 #' @seealso [symncmp()] for symbolic number comparison.
 #' @export
-nsymncmp <- function(data, .input = NULL, .extra = NULL) {
+nsymncmp <- function(data, .by = NULL, .input = NULL, .extra = NULL) {
   .input <- list(
     name_bigset = "bigsetcount",
     name_smallset = "smallsetcount",
@@ -18,22 +21,28 @@ nsymncmp <- function(data, .input = NULL, .extra = NULL) {
     name_rt = "rt"
   ) |>
     update_settings(.input)
-  bind_cols(
+  merge(
     calc_spd_acc(
       data,
+      by = .by,
       name_acc = .input$name_acc,
-      name_rt = .input$name_rt,
-      rt_rtn = "mean",
-      acc_rtn = "percent",
-      sat_rtn = "none"
+      name_rt = .input$name_rt
     ),
-    calc_numerosity(
-      data,
-      name_bigset = .input$name_bigset,
-      name_smallset = .input$name_smallset,
-      name_acc = .input$name_acc
-    )
-  )
+    data |>
+      group_by(across(all_of(.by))) |>
+      group_modify(
+        ~ calc_numerosity(
+          .,
+          name_bigset = .input$name_bigset,
+          name_smallset = .input$name_smallset,
+          name_acc = .input$name_acc
+        )
+      ) |>
+      ungroup(),
+    by = .by
+  ) |>
+    select(all_of(c(.by, "pc", "mrt", "w"))) |>
+    vctrs::vec_restore(data)
 }
 
 calc_numerosity <- function(data, name_bigset, name_smallset, name_acc) {

--- a/R/rapm.R
+++ b/R/rapm.R
@@ -6,7 +6,7 @@
 #'
 #' @template common
 #' @template options
-#' @return A [tibble][tibble::tibble-package] contains following values:
+#' @return An object with the same class as `data` contains following values:
 #'
 #'   \item{nc_prac}{Number of correct items for set I.}
 #'
@@ -15,7 +15,7 @@
 #'   \item{nc_total}{Number of correct items for whole set.}
 #'
 #' @export
-rapm <- function(data, .input = NULL, .extra = NULL) {
+rapm <- function(data, .by = NULL, .input = NULL, .extra = NULL) {
   .input <- list(name_block = "block", name_acc = "acc") |>
     update_settings(.input)
   .extra <- list(block_prac = 1, block_test = 2) |>
@@ -27,13 +27,17 @@ rapm <- function(data, .input = NULL, .extra = NULL) {
         .data[[.input$name_block]] %in% .extra$block_test ~ "test"
       )
     ) |>
-    group_by(.data$block) |>
-    group_modify(~ countcorrect(.x, .input = .input, .extra = .extra)) |>
-    ungroup() |>
+    countcorrect(
+      .by = c("block", .by),
+      .input = .input,
+      .extra = .extra
+    ) |>
     pivot_wider(
+      id_cols = all_of(.by),
       names_from = .data$block,
       values_from = .data$nc,
       names_prefix = "nc_"
     ) |>
-    mutate(nc_total = .data$nc_prac + .data$nc_test)
+    mutate(nc_total = .data$nc_prac + .data$nc_test) |>
+    vctrs::vec_restore(data)
 }

--- a/R/refframe.R
+++ b/R/refframe.R
@@ -5,14 +5,14 @@
 #'
 #' @template common
 #' @template options
-#' @return A [tibble][tibble::tibble-package] contains following values:
+#' @return An object with the same class as `data` contains following values:
 #'   \item{mean_dist_err_allo/mean_dist_err_ego}{Mean of the response distance
 #'     errors for allocentric and egocentric conditions respectively.}
 #'   \item{mean_log_err_allo/mean_log_err_ego}{Mean of the log-transformed (of
 #'     base \eqn{e}) response distance errors for allocentric and egocentric
 #'     conditions respectively.}
 #' @export
-refframe <- function(data, .input = NULL, .extra = NULL) {
+refframe <- function(data, .by = NULL, .input = NULL, .extra = NULL) {
   .input <- list(name_type = "type", name_dist = "dist") |>
     update_settings(.input)
   .extra <- list(type_allo = "allocentric", type_ego = "egocentric") |>
@@ -29,14 +29,16 @@ refframe <- function(data, .input = NULL, .extra = NULL) {
         .data[[.input$name_type]] == .extra$type_ego ~ "ego"
       )
     ) |>
-    group_by(.data$type_cor) |>
+    group_by(across(all_of(c(.by, "type_cor")))) |>
     summarise(
       mean_dist_err = mean(.data[[.input$name_dist]]),
       mean_log_err = mean(log(.data[[.input$name_dist]] + 1)),
       .groups = "drop"
     ) |>
     pivot_wider(
+      id_cols = all_of(.by),
       names_from = .data$type_cor,
       values_from = starts_with("mean")
-    )
+    ) |>
+    vctrs::vec_restore(data)
 }

--- a/R/reinf.R
+++ b/R/reinf.R
@@ -4,7 +4,7 @@
 #'
 #' @template common
 #' @template options
-#' @return A [tibble][tibble::tibble-package] contains following values:
+#' @return An object with the same class as `data` contains following values:
 #'
 #'   \item{pc_approach}{The percent of correct for approach trials.}
 #'
@@ -14,7 +14,7 @@
 #'
 #'   \item{pc_test}{The total percent of correct in the test phase.}
 #' @export
-reinf <- function(data, .input = NULL, .extra = NULL) {
+reinf <- function(data, .by = NULL, .input = NULL, .extra = NULL) {
   .input <- list(
     name_phase = "phase",
     name_cresp = "cresp",
@@ -43,14 +43,16 @@ reinf <- function(data, .input = NULL, .extra = NULL) {
         .data$set
       )
     ) |>
-    group_by(.data$set) |>
+    group_by(across(all_of(c(.by, "set")))) |>
     summarise(
       pc = mean(.data[[.input$name_acc]]),
       .groups = "drop"
     ) |>
     pivot_wider(
+      id_cols = all_of(.by),
       names_from = "set",
       values_from = "pc",
       names_prefix = "pc_"
-    )
+    ) |>
+    vctrs::vec_restore(data)
 }

--- a/R/rt.R
+++ b/R/rt.R
@@ -8,13 +8,13 @@
 #' @name rt
 #' @template common
 #' @template options
-#' @return A [tibble][tibble::tibble-package] contains following values:
+#' @return An object with the same class as `data` contains following values:
+#'
+#'   \item{nc}{Count of correct responses. Only for [crt()].}
 #'
 #'   \item{mrt}{Mean reaction time.}
 #'
 #'   \item{rtsd}{Standard deviation of reaction times.}
-#'
-#'   \item{nc}{Count of correct responses. Only for [crt()].}
 #'
 #'   \item{ies}{Inverse efficiency score. Only for [crt()].}
 #'
@@ -25,28 +25,39 @@ NULL
 
 #' @rdname rt
 #' @export
-crt <- function(data, .input = NULL, .extra = NULL) {
+crt <- function(data, .by = NULL, .input = NULL, .extra = NULL) {
   .input <- list(name_acc = "acc", name_rt = "rt") |>
     update_settings(.input)
   calc_spd_acc(
     data,
+    by = .by,
     name_acc = .input$name_acc,
-    name_rt = .input$name_rt,
-    acc_rtn = "count"
-  )
+    name_rt = .input$name_rt
+  ) |>
+    select(
+      all_of(
+        c(
+          .by,
+          "nc", "mrt", "rtsd",
+          "ies", "rcs", "lisas"
+        )
+      )
+    ) |>
+    vctrs::vec_restore(data)
 }
 
 #' @rdname rt
 #' @export
-srt <- function(data, .input = NULL, .extra = NULL) {
+srt <- function(data, .by = NULL, .input = NULL, .extra = NULL) {
   .input <- list(name_rt = "rt") |>
     update_settings(.input)
   data |>
     mutate(acc_dummy = 1) |>
     calc_spd_acc(
+      by = .by,
       name_acc = "acc_dummy",
-      name_rt = .input$name_rt,
-      acc_rtn = "none",
-      sat_rtn = "none"
-    )
+      name_rt = .input$name_rt
+    ) |>
+    select(all_of(c(.by, "mrt", "rtsd"))) |>
+    vctrs::vec_restore(data)
 }

--- a/R/span.R
+++ b/R/span.R
@@ -4,7 +4,7 @@
 #'
 #' @template common
 #' @template options
-#' @return A [tibble][tibble::tibble-package] contains following values:
+#' @return An object with the same class as `data` contains following values:
 #'
 #'   \item{nc}{Count of correct responses.}
 #'
@@ -15,7 +15,7 @@
 #'   \item{mean_span_anu}{Mean span using all-or-nothing unit score.}
 #'
 #' @export
-span <- function(data, .input = NULL, .extra = NULL) {
+span <- function(data, .by = NULL, .input = NULL, .extra = NULL) {
   .input <- list(
     name_slen = "slen",
     name_outcome = "outcome",
@@ -50,12 +50,12 @@ span <- function(data, .input = NULL, .extra = NULL) {
       acc = parse_char_resp(.data[[.input$name_acc]]),
       nc = purrr::map_dbl(.data$acc, ~ sum(.x == 1))
     ) |>
-    group_by(.data[[.input$name_slen]]) |>
+    group_by(across(all_of(c(.by, .input$name_slen)))) |>
     summarise(
       nc = sum(.data$nc),
       pcu = sum(.data$nc) / sum(.data[[.input$name_slen]]),
       anu = mean(.data[[.input$name_outcome]] == 1),
-      .groups = "drop"
+      .groups = "drop_last"
     ) |>
     summarise(
       nc = sum(.data$nc),
@@ -65,6 +65,8 @@ span <- function(data, .input = NULL, .extra = NULL) {
       mean_span_pcu = min(.data[[.input$name_slen]]) +
         sum(.data$pcu) - 1,
       mean_span_anu = min(.data[[.input$name_slen]]) +
-        sum(.data$anu) - 0.5
-    )
+        sum(.data$anu) - 0.5,
+      .groups = "drop"
+    ) |>
+    vctrs::vec_restore(data)
 }

--- a/R/staircase.R
+++ b/R/staircase.R
@@ -8,14 +8,14 @@
 #'
 #' @template common
 #' @template options
-#' @return A [tibble][tibble::tibble-package] contains following values:
+#' @return An object with the same class as `data` contains following values:
 #'
 #'   \item{thresh_peak_valley}{The mean threshold of peaks and valleys.}
 #'
 #'   \item{thresh_last_block}{The mean threshold of the last block.}
 #'
 #' @export
-staircase <- function(data, .input = NULL, .extra = NULL) {
+staircase <- function(data, .by = NULL, .input = NULL, .extra = NULL) {
   .input <- list(
     name_block = "block",
     name_level = "level",
@@ -23,6 +23,7 @@ staircase <- function(data, .input = NULL, .extra = NULL) {
   ) |>
     update_settings(.input)
   data |>
+    group_by(across(all_of(.by))) |>
     summarise(
       thresh_peak_valley = calc_staircase_wetherill(.data[[.input$name_level]]),
       thresh_last_block = mean(
@@ -32,6 +33,8 @@ staircase <- function(data, .input = NULL, .extra = NULL) {
             .data[[.input$name_block]] == max(.data[[.input$name_block]])
           )
         )$values
-      )
-    )
+      ),
+      .groups = "drop"
+    ) |>
+    vctrs::vec_restore(data)
 }

--- a/R/switch-congruence.R
+++ b/R/switch-congruence.R
@@ -35,7 +35,7 @@ NULL
 
 #' @rdname switch-congruence
 #' @export
-complexswitch <- function(data, .input = NULL, .extra = NULL) {
+complexswitch <- function(data, .by = NULL, .input = NULL, .extra = NULL) {
   .input <- list(
     name_cong = "stimtype",
     name_task = "task",
@@ -54,12 +54,11 @@ complexswitch <- function(data, .input = NULL, .extra = NULL) {
     update_settings(.extra)
   spd_acc <- calc_spd_acc(
     data,
+    by = .by,
     name_acc = .input$name_acc,
-    name_rt = .input$name_rt,
-    acc_rtn = "percent",
-    rt_rtn = "mean",
-    sat_rtn = "none"
-  )
+    name_rt = .input$name_rt
+  ) |>
+    select(all_of(c(.by, "pc", "mrt")))
   switch_cost <- data |>
     filter(.data[[.input$name_switch]] != .extra$task_filler) |>
     mutate(
@@ -70,6 +69,7 @@ complexswitch <- function(data, .input = NULL, .extra = NULL) {
       )
     ) |>
     calc_switch_cost(
+      by = .by,
       name_switch = "switch",
       name_acc = .input$name_acc,
       name_rt = .input$name_rt
@@ -83,16 +83,20 @@ complexswitch <- function(data, .input = NULL, .extra = NULL) {
       )
     ) |>
     calc_cong_eff(
+      by = .by,
       name_cong = "stim_type",
       name_acc = .input$name_acc,
       name_rt = .input$name_rt
     )
-  bind_cols(spd_acc, switch_cost, cong_eff)
+  spd_acc |>
+    merge(switch_cost, by = .by) |>
+    merge(cong_eff, by = .by) |>
+    vctrs::vec_restore(data)
 }
 
 #' @rdname switch-congruence
 #' @export
-congeff <- function(data, .input = NULL, .extra = NULL) {
+congeff <- function(data, .by = NULL, .input = NULL, .extra = NULL) {
   .input <- list(
     name_cong = "type",
     name_acc = "acc",
@@ -106,12 +110,11 @@ congeff <- function(data, .input = NULL, .extra = NULL) {
     update_settings(.extra)
   spd_acc <- calc_spd_acc(
     data,
+    by = .by,
     name_acc = .input$name_acc,
-    name_rt = .input$name_rt,
-    acc_rtn = "percent",
-    rt_rtn = "mean",
-    sat_rtn = "none"
-  )
+    name_rt = .input$name_rt
+  ) |>
+    select(all_of(c(.by, "pc", "mrt")))
   cong_eff <- data |>
     mutate(
       stim_type = recode(
@@ -121,16 +124,18 @@ congeff <- function(data, .input = NULL, .extra = NULL) {
       )
     ) |>
     calc_cong_eff(
+      by = .by,
       name_cong = "stim_type",
       name_acc = .input$name_acc,
       name_rt = .input$name_rt
     )
-  bind_cols(spd_acc, cong_eff)
+  merge(spd_acc, cong_eff, by = .by) |>
+    vctrs::vec_restore(data)
 }
 
 #' @rdname switch-congruence
 #' @export
-switchcost <- function(data, .input = NULL, .extra = NULL) {
+switchcost <- function(data, .by = NULL, .input = NULL, .extra = NULL) {
   .input <- list(
     name_switch = "type",
     name_acc = "acc",
@@ -145,12 +150,11 @@ switchcost <- function(data, .input = NULL, .extra = NULL) {
     update_settings(.extra)
   spd_acc <- calc_spd_acc(
     data,
+    by = .by,
     name_acc = .input$name_acc,
-    name_rt = .input$name_rt,
-    acc_rtn = "percent",
-    rt_rtn = "mean",
-    sat_rtn = "none"
-  )
+    name_rt = .input$name_rt
+  ) |>
+    select(all_of(c(.by, "pc", "mrt")))
   switch_cost <- data |>
     filter(.data[[.input$name_switch]] != .extra$task_filler) |>
     mutate(
@@ -161,9 +165,11 @@ switchcost <- function(data, .input = NULL, .extra = NULL) {
       )
     ) |>
     calc_switch_cost(
+      by = .by,
       name_switch = "switch",
       name_acc = .input$name_acc,
       name_rt = .input$name_rt
     )
-  bind_cols(spd_acc, switch_cost)
+  merge(spd_acc, switch_cost, by = .by) |>
+    vctrs::vec_restore(data)
 }

--- a/R/synwin.R
+++ b/R/synwin.R
@@ -4,7 +4,7 @@
 #'
 #' @template common
 #' @template options
-#' @return A [tibble][tibble::tibble-package] contains following values:
+#' @return An object with the same class as `data` contains following values:
 #'
 #'   \item{score_total}{Total score. Sum of the three sub-tests.}
 #'
@@ -15,7 +15,7 @@
 #'   \item{score_aud}{Score in auditory monitoring sub-test.}
 #'
 #' @export
-synwin <- function(data, .input = NULL, .extra = NULL) {
+synwin <- function(data, .by = NULL, .input = NULL, .extra = NULL) {
   .input <- list(
     name_status = "status",
     name_acc = "acc"
@@ -50,12 +50,14 @@ synwin <- function(data, .input = NULL, .extra = NULL) {
           ) * (.data[[.input$name_acc]] * 2 - 1)
       )
     ) |>
-    group_by(.data$task) |>
-    summarise(score = sum(.data$score), .groups = "drop") |>
+    group_by(across(all_of(c(.by, "task")))) |>
+    summarise(score = sum(.data$score), .groups = "drop_last") |>
     mutate(score_total = sum(.data$score)) |>
+    ungroup() |>
     pivot_wider(
       names_from = .data$task,
       names_prefix = "score_",
       values_from = .data$score
-    )
+    ) |>
+    vctrs::vec_restore(data)
 }

--- a/R/utils-speed-accuracy.R
+++ b/R/utils-speed-accuracy.R
@@ -26,7 +26,7 @@
 #' @param rt_unit The unit of response time in `data`.
 #' @return A [tibble][tibble::tibble-package] contains the required scores.
 #' @keywords internal
-calc_spd_acc <- function(data, by, name_acc, name_rt,
+calc_spd_acc <- function(data, by = NULL, name_acc = "acc", name_rt = "rt",
                          rt_rm_out = TRUE, rt_unit = c("ms", "s")) {
   rt_unit <- match.arg(rt_unit)
   # set reaction time unit to seconds for better value range
@@ -95,7 +95,7 @@ calc_spd_acc <- function(data, by, name_acc, name_rt,
 #' @return A [tibble][tibble::tibble-package] contains sensitivity index and
 #'   bias (and other counts measures)
 #' @keywords internal
-calc_sdt <- function(data, by, name_acc, name_type) {
+calc_sdt <- function(data, by = NULL, name_acc = "acc", name_type = "type") {
   data |>
     mutate(
       type_fac = factor(

--- a/R/utils-speed-accuracy.R
+++ b/R/utils-speed-accuracy.R
@@ -16,68 +16,65 @@
 #'   & Chartier, S. (2010).
 #'
 #' @template common
+#' @param by The column name(s) in `data` used to be grouped by. If set to
+#'   `NULL`, all data will be treated as from one subject.
 #' @templateVar name_acc TRUE
 #' @templateVar name_rt TRUE
 #' @template names
 #' @param rt_rm_out A logical value. Whether remove response time outlier or
 #'   not. Default to `TRUE.`
 #' @param rt_unit The unit of response time in `data`.
-#' @param rt_rtn If mean or standard deviation of response times should be
-#'   returned.
-#' @param acc_rtn If count or percent of correct responses should be returned.
-#' @param sat_rtn If any of the speed-accuracy trade-off index should be
-#'   returned. `"IES"`, `"RCS"` and `"LISAS"` are supported.
 #' @return A [tibble][tibble::tibble-package] contains the required scores.
 #' @keywords internal
-calc_spd_acc <- function(data, name_acc, name_rt,
-                         rt_rm_out = TRUE, rt_unit = c("ms", "s"),
-                         rt_rtn = c("both", "mean", "sd", "none"),
-                         acc_rtn = c("both", "count", "percent", "none"),
-                         sat_rtn = c("all", "ies", "rcs", "lisas", "none")) {
+calc_spd_acc <- function(data, by, name_acc, name_rt,
+                         rt_rm_out = TRUE, rt_unit = c("ms", "s")) {
   rt_unit <- match.arg(rt_unit)
   # set reaction time unit to seconds for better value range
   if (rt_unit == "ms") data[[name_rt]] <- data[[name_rt]] / 1000
-  rt_rtn <- match.arg(rt_rtn)
-  acc_rtn <- match.arg(acc_rtn)
-  sat_rtn <- match.arg(sat_rtn)
-  nc <- sum(data[[name_acc]] == 1)
-  pc <- nc / nrow(data)
-  pcsd <- stats::sd(data[[name_acc]] == 1)
-  rt_all <- data[[name_rt]]
-  # rt of 0 or `NA` means no response or irrelavant response
-  keep_rows <- rt_all != 0 & !is.na(rt_all)
-  rt_all <- rt_all[keep_rows]
-  if (rt_rm_out) {
-    is_outlier <- check_outliers_rt(rt_all)
-    rt_correct <- .subset(
-      rt_all,
-      data[[name_acc]][keep_rows] == 1 & !is_outlier
+  data |>
+    # rt of 0 means no response and should be converted as `NA
+    mutate(na_if(.data[[name_rt]], 0)) |>
+    group_by(across(all_of(by))) |>
+    mutate(is_outlier = check_outliers_rt(.data[[name_rt]])) |>
+    summarise(
+      nc = sum(.data[[name_acc]] == 1),
+      pc = .data$nc / n(),
+      pcsd = stats::sd(.data[[name_acc]] == 1),
+      mrt = if (rt_rm_out) {
+        .data[[name_rt]] |>
+          .subset(!.data$is_outlier & .data[[name_acc]] == 1) |>
+          mean.default(na.rm = TRUE)
+      } else {
+        .data[[name_rt]] |>
+          .subset(.data[[name_acc]] == 1) |>
+          mean.default(na.rm = TRUE)
+      },
+      mrt_all = if (rt_rm_out) {
+        .data[[name_rt]] |>
+          .subset(!.data$is_outlier) |>
+          mean.default(na.rm = TRUE)
+      } else {
+        .data[[name_rt]] |>
+          mean.default(na.rm = TRUE)
+      },
+      rtsd  = if (rt_rm_out) {
+        .data[[name_rt]] |>
+          .subset(!.data$is_outlier & .data[[name_acc]] == 1) |>
+          stats::sd(na.rm = TRUE)
+      } else {
+        .data[[name_rt]] |>
+          .subset(.data[[name_acc]] == 1) |>
+          stats::sd(na.rm = TRUE)
+      },
+      ies = .data$mrt / .data$pc,
+      rcs = .data$pc / .data$mrt_all,
+      lisas = case_when(
+        .data$pc == 1 ~ .data$mrt,
+        .data$pc == 0 ~ 0,
+        TRUE ~ .data$mrt + (1 - .data$pc) / .data$pcsd * .data$rtsd
+      ),
+      .groups = "drop"
     )
-    rt_all <- .subset(rt_all, !is_outlier)
-  } else {
-    rt_correct <- rt_all |>
-      .subset(data[[name_acc]][keep_rows] == 1)
-  }
-  mrt <- mean(rt_correct)
-  rtsd <- stats::sd(rt_correct)
-  ies <- mrt / pc
-  rcs <- pc / mean(rt_all)
-  lisas <- if (pc == 1) {
-    mrt
-  } else if (pc == 0) {
-    0
-  } else {
-    mrt + (1 - pc) / pcsd * rtsd
-  }
-  tibble(
-    nc = if (acc_rtn %in% c("both", "count")) nc,
-    pc = if (acc_rtn %in% c("both", "percent")) pc,
-    mrt = if (rt_rtn %in% c("both", "mean")) mrt,
-    rtsd = if (rt_rtn %in% c("both", "sd")) rtsd,
-    ies = if (sat_rtn %in% c("all", "ies")) ies,
-    rcs = if (sat_rtn %in% c("all", "rcs")) rcs,
-    lisas = if (sat_rtn %in% c("all", "lisas")) lisas
-  )
 }
 
 #' Signal Detection Theory
@@ -87,21 +84,18 @@ calc_spd_acc <- function(data, name_acc, name_rt,
 #' recommended by Hautus (1995).
 #'
 #' @template common
+#' @param by The column name(s) in `data` used to be grouped by. If set to
+#'   `NULL`, all data will be treated as from one subject.
 #' @templateVar name_acc TRUE
 #' @template names
 #' @param name_type The column name of the `data` input whose values are the
 #'   stimuli types, in which is a `character` vector with value `"s"` (denoting
 #'   "*signal*") and `"n"` (denoting "*non-signal*") only. It will be coerced as
 #'   a `factor` vector with these two levels.
-#' @param keep_bias A logical value. Whether the bias index be returned. Default
-#'   is `TRUE`.
-#' @param keep_counts A logical value. Whether the counts of errors (commissions
-#'   and omissions) be returned. Default is `TRUE`.
 #' @return A [tibble][tibble::tibble-package] contains sensitivity index and
 #'   bias (and other counts measures)
 #' @keywords internal
-calc_sdt <- function(data, name_acc, name_type,
-                     keep_bias = TRUE, keep_counts = TRUE) {
+calc_sdt <- function(data, by, name_acc, name_type) {
   data |>
     mutate(
       type_fac = factor(
@@ -109,7 +103,7 @@ calc_sdt <- function(data, name_acc, name_type,
         c("s", "n")
       )
     ) |>
-    group_by(.data$type_fac) |>
+    group_by(across(all_of(c(by, "type_fac")))) |>
     summarise(
       c = sum(.data[[name_acc]] == 1),
       e = n() - .data$c,
@@ -128,10 +122,10 @@ calc_sdt <- function(data, name_acc, name_type,
       names_from = .data$type_fac,
       values_from = c("c", "e", "zc", "ze")
     ) |>
-    transmute(
+    mutate(
       dprime = .data$zc_s - .data$ze_n,
-      c = if(keep_bias) -(.data$zc_s + .data$ze_n) / 2,
-      commissions = if (keep_counts) .data$e_n,
-      omissions = if (keep_counts) .data$e_s
+      c = -(.data$zc_s + .data$ze_n) / 2,
+      commissions = .data$e_n,
+      omissions = .data$e_s
     )
 }

--- a/man-roxygen/options.R
+++ b/man-roxygen/options.R
@@ -1,3 +1,6 @@
+#' @param .by The column name(s) in `data` used to be grouped by. If set to
+#'   `NULL` (default), all data will be treated as from one subject and there
+#'   will be no grouping columns in the value returned.
 #' @param .input,.extra Each is a [list()] containing all the input variable
 #'   names and special values for certain variables. See more in the details
 #'   section.

--- a/man/bart.Rd
+++ b/man/bart.Rd
@@ -4,17 +4,21 @@
 \alias{bart}
 \title{Balloon Analogue Risk Task}
 \usage{
-bart(data, .input = NULL, .extra = NULL)
+bart(data, .by = NULL, .input = NULL, .extra = NULL)
 }
 \arguments{
 \item{data}{Raw data of class \code{data.frame}.}
+
+\item{.by}{The column name(s) in \code{data} used to be grouped by. If set to
+\code{NULL} (default), all data will be treated as from one subject and there
+will be no grouping columns in the value returned.}
 
 \item{.input, .extra}{Each is a \code{\link[=list]{list()}} containing all the input variable
 names and special values for certain variables. See more in the details
 section.}
 }
 \value{
-A \link[tibble:tibble-package]{tibble} contains following values:
+An object with the same class as \code{data} contains following values:
 \item{mean_pumps}{Mean of hits for balloons not exploded.}
 \item{mean_pumps_raw}{Mean of hits for all balloons.}
 \item{num_explosion}{Number of exploded balloons.}

--- a/man/bps.Rd
+++ b/man/bps.Rd
@@ -4,17 +4,21 @@
 \alias{bps}
 \title{Behavioral Pattern Separation (BPS) task}
 \usage{
-bps(data, .input = NULL, .extra = NULL)
+bps(data, .by = NULL, .input = NULL, .extra = NULL)
 }
 \arguments{
 \item{data}{Raw data of class \code{data.frame}.}
+
+\item{.by}{The column name(s) in \code{data} used to be grouped by. If set to
+\code{NULL} (default), all data will be treated as from one subject and there
+will be no grouping columns in the value returned.}
 
 \item{.input, .extra}{Each is a \code{\link[=list]{list()}} containing all the input variable
 names and special values for certain variables. See more in the details
 section.}
 }
 \value{
-A \link[tibble:tibble-package]{tibble} contains following values:
+An object with the same class as \code{data} contains following values:
 \item{pc}{Percent of correct responses.}
 \item{p_sim_foil}{Percent of similar responses for "foil" stimuli.}
 \item{p_sim_lure}{Percent of similar responses for "lure" stimuli.}

--- a/man/calc_cong_eff.Rd
+++ b/man/calc_cong_eff.Rd
@@ -4,10 +4,13 @@
 \alias{calc_cong_eff}
 \title{Congruence effect}
 \usage{
-calc_cong_eff(data, name_cong, name_acc, name_rt)
+calc_cong_eff(data, by, name_cong, name_acc, name_rt)
 }
 \arguments{
 \item{data}{Raw data of class \code{data.frame}.}
+
+\item{by}{The column name(s) in \code{data} used to be grouped by. If set to
+\code{NULL}, all data will be treated as from one subject.}
 
 \item{name_cong}{The column name of the \code{data} input whose values are the
 congruence information, in which is a \code{character} vector with "incongruent

--- a/man/calc_sdt.Rd
+++ b/man/calc_sdt.Rd
@@ -4,10 +4,13 @@
 \alias{calc_sdt}
 \title{Signal Detection Theory}
 \usage{
-calc_sdt(data, name_acc, name_type, keep_bias = TRUE, keep_counts = TRUE)
+calc_sdt(data, by, name_acc, name_type)
 }
 \arguments{
 \item{data}{Raw data of class \code{data.frame}.}
+
+\item{by}{The column name(s) in \code{data} used to be grouped by. If set to
+\code{NULL}, all data will be treated as from one subject.}
 
 \item{name_acc}{The column name of the \code{data} input whose values are user's correctness, in which is a \code{numeric} vector so coded that 1 means scoring correct, 0 means scoring incorrect, and that -1 means no response is made.}
 
@@ -15,12 +18,6 @@ calc_sdt(data, name_acc, name_type, keep_bias = TRUE, keep_counts = TRUE)
 stimuli types, in which is a \code{character} vector with value \code{"s"} (denoting
 "\emph{signal}") and \code{"n"} (denoting "\emph{non-signal}") only. It will be coerced as
 a \code{factor} vector with these two levels.}
-
-\item{keep_bias}{A logical value. Whether the bias index be returned. Default
-is \code{TRUE}.}
-
-\item{keep_counts}{A logical value. Whether the counts of errors (commissions
-and omissions) be returned. Default is \code{TRUE}.}
 }
 \value{
 A \link[tibble:tibble-package]{tibble} contains sensitivity index and

--- a/man/calc_sdt.Rd
+++ b/man/calc_sdt.Rd
@@ -4,7 +4,7 @@
 \alias{calc_sdt}
 \title{Signal Detection Theory}
 \usage{
-calc_sdt(data, by, name_acc, name_type)
+calc_sdt(data, by = NULL, name_acc = "acc", name_type = "type")
 }
 \arguments{
 \item{data}{Raw data of class \code{data.frame}.}

--- a/man/calc_spd_acc.Rd
+++ b/man/calc_spd_acc.Rd
@@ -6,9 +6,9 @@
 \usage{
 calc_spd_acc(
   data,
-  by,
-  name_acc,
-  name_rt,
+  by = NULL,
+  name_acc = "acc",
+  name_rt = "rt",
   rt_rm_out = TRUE,
   rt_unit = c("ms", "s")
 )

--- a/man/calc_spd_acc.Rd
+++ b/man/calc_spd_acc.Rd
@@ -6,17 +6,18 @@
 \usage{
 calc_spd_acc(
   data,
+  by,
   name_acc,
   name_rt,
   rt_rm_out = TRUE,
-  rt_unit = c("ms", "s"),
-  rt_rtn = c("both", "mean", "sd", "none"),
-  acc_rtn = c("both", "count", "percent", "none"),
-  sat_rtn = c("all", "ies", "rcs", "lisas", "none")
+  rt_unit = c("ms", "s")
 )
 }
 \arguments{
 \item{data}{Raw data of class \code{data.frame}.}
+
+\item{by}{The column name(s) in \code{data} used to be grouped by. If set to
+\code{NULL}, all data will be treated as from one subject.}
 
 \item{name_acc}{The column name of the \code{data} input whose values are user's correctness, in which is a \code{numeric} vector so coded that 1 means scoring correct, 0 means scoring incorrect, and that -1 means no response is made.}
 
@@ -26,14 +27,6 @@ calc_spd_acc(
 not. Default to \code{TRUE.}}
 
 \item{rt_unit}{The unit of response time in \code{data}.}
-
-\item{rt_rtn}{If mean or standard deviation of response times should be
-returned.}
-
-\item{acc_rtn}{If count or percent of correct responses should be returned.}
-
-\item{sat_rtn}{If any of the speed-accuracy trade-off index should be
-returned. \code{"IES"}, \code{"RCS"} and \code{"LISAS"} are supported.}
 }
 \value{
 A \link[tibble:tibble-package]{tibble} contains the required scores.

--- a/man/calc_switch_cost.Rd
+++ b/man/calc_switch_cost.Rd
@@ -4,10 +4,13 @@
 \alias{calc_switch_cost}
 \title{Switch cost}
 \usage{
-calc_switch_cost(data, name_switch, name_rt, name_acc)
+calc_switch_cost(data, by, name_switch, name_rt, name_acc)
 }
 \arguments{
 \item{data}{Raw data of class \code{data.frame}.}
+
+\item{by}{The column name(s) in \code{data} used to be grouped by. If set to
+\code{NULL}, all data will be treated as from one subject.}
 
 \item{name_switch}{The column name of the \code{data} input whose values are
 the switch type, in which is a \code{character} vector with at least \code{"switch"}

--- a/man/counts.Rd
+++ b/man/counts.Rd
@@ -8,23 +8,27 @@
 \alias{sumscore}
 \title{Count Correct Responses}
 \usage{
-countcorrect(data, .input = NULL, .extra = NULL)
+countcorrect(data, .by = NULL, .input = NULL, .extra = NULL)
 
-countcorrect2(data, .input = NULL, .extra = NULL)
+countcorrect2(data, .by = NULL, .input = NULL, .extra = NULL)
 
-sumweighted(data, .input = NULL, .extra = NULL)
+sumweighted(data, .by = NULL, .input = NULL, .extra = NULL)
 
-sumscore(data, .input = NULL, .extra = NULL)
+sumscore(data, .by = NULL, .input = NULL, .extra = NULL)
 }
 \arguments{
 \item{data}{Raw data of class \code{data.frame}.}
+
+\item{.by}{The column name(s) in \code{data} used to be grouped by. If set to
+\code{NULL} (default), all data will be treated as from one subject and there
+will be no grouping columns in the value returned.}
 
 \item{.input, .extra}{Each is a \code{\link[=list]{list()}} containing all the input variable
 names and special values for certain variables. See more in the details
 section.}
 }
 \value{
-A \link[tibble:tibble-package]{tibble} contains following values:
+An object with the same class as \code{data} contains following values:
 \item{nc}{Count of correct responses. For \code{\link[=countcorrect]{countcorrect()}}.}
 \item{nc_cor}{Corrected count of correct responses (subtracting number of
 errors). For \code{\link[=countcorrect2]{countcorrect2()}}.}

--- a/man/cpt.Rd
+++ b/man/cpt.Rd
@@ -4,33 +4,29 @@
 \alias{cpt}
 \title{Continuous Performance Test}
 \usage{
-cpt(data, .input = NULL, .extra = NULL)
+cpt(data, .by = NULL, .input = NULL, .extra = NULL)
 }
 \arguments{
 \item{data}{Raw data of class \code{data.frame}.}
+
+\item{.by}{The column name(s) in \code{data} used to be grouped by. If set to
+\code{NULL} (default), all data will be treated as from one subject and there
+will be no grouping columns in the value returned.}
 
 \item{.input, .extra}{Each is a \code{\link[=list]{list()}} containing all the input variable
 names and special values for certain variables. See more in the details
 section.}
 }
 \value{
-A \link[tibble:tibble-package]{tibble} contains following values:
+An object with the same class as \code{data} contains following values:
 
-\item{nc}{Count of correct responses.}
+\item{pc}{Percent of correct responses.}
 
 \item{mrt}{Mean reaction time of hits.}
 
 \item{rtsd}{Standard deviation of reaction times of hits.}
 
 \item{dprime}{Sensitivity (d').}
-
-\item{c}{Bias index.}
-
-\item{ies}{Inverse efficiency score.}
-
-\item{rcs}{Rate correct score.}
-
-\item{lisas}{Linear integrated speed-accuracy score.}
 
 \item{commissions}{Number of errors caused by action.}
 

--- a/man/driving.Rd
+++ b/man/driving.Rd
@@ -4,17 +4,21 @@
 \alias{driving}
 \title{Driving Test}
 \usage{
-driving(data, .input = NULL, .extra = NULL)
+driving(data, .by = NULL, .input = NULL, .extra = NULL)
 }
 \arguments{
 \item{data}{Raw data of class \code{data.frame}.}
+
+\item{.by}{The column name(s) in \code{data} used to be grouped by. If set to
+\code{NULL} (default), all data will be treated as from one subject and there
+will be no grouping columns in the value returned.}
 
 \item{.input, .extra}{Each is a \code{\link[=list]{list()}} containing all the input variable
 names and special values for certain variables. See more in the details
 section.}
 }
 \value{
-A \link[tibble:tibble-package]{tibble} contains following values:
+An object with the same class as \code{data} contains following values:
 \item{still_ratio}{The ratio of still duration in yellow light state.}
 }
 \description{

--- a/man/drm.Rd
+++ b/man/drm.Rd
@@ -4,20 +4,28 @@
 \alias{drm}
 \title{Deese-Roediger-McDermott (DRM) paradigm}
 \usage{
-drm(data, .input = NULL, .extra = NULL)
+drm(data, .by = NULL, .input = NULL, .extra = NULL)
 }
 \arguments{
 \item{data}{Raw data of class \code{data.frame}.}
+
+\item{.by}{The column name(s) in \code{data} used to be grouped by. If set to
+\code{NULL} (default), all data will be treated as from one subject and there
+will be no grouping columns in the value returned.}
 
 \item{.input, .extra}{Each is a \code{\link[=list]{list()}} containing all the input variable
 names and special values for certain variables. See more in the details
 section.}
 }
 \value{
-A \link[tibble:tibble-package]{tibble} contains following values:
+An object with the same class as \code{data} contains following values:
+
 \item{tm_dprime}{Sensitivity (d') of true memory (against "foil" stimuli).}
+
 \item{tm_bias}{Bias of true memory (against "foil" stimuli).}
+
 \item{fm_dprime}{Sensitivity (d') of false memory.}
+
 \item{fm_bias}{ias of false memory.}
 }
 \description{

--- a/man/igt.Rd
+++ b/man/igt.Rd
@@ -4,18 +4,24 @@
 \alias{igt}
 \title{Iowa Gambling Task (modified)}
 \usage{
-igt(data, .input = NULL, .extra = NULL)
+igt(data, .by = NULL, .input = NULL, .extra = NULL)
 }
 \arguments{
 \item{data}{Raw data of class \code{data.frame}.}
+
+\item{.by}{The column name(s) in \code{data} used to be grouped by. If set to
+\code{NULL} (default), all data will be treated as from one subject and there
+will be no grouping columns in the value returned.}
 
 \item{.input, .extra}{Each is a \code{\link[=list]{list()}} containing all the input variable
 names and special values for certain variables. See more in the details
 section.}
 }
 \value{
-A \link[tibble:tibble-package]{tibble} contains following values:
+An object with the same class as \code{data} contains following values:
+
 \item{sum_outcome}{The total outcome over all trials.}
+
 \item{perc_good}{The number of choices on "good" pools.}
 }
 \description{

--- a/man/jlo.Rd
+++ b/man/jlo.Rd
@@ -4,19 +4,26 @@
 \alias{jlo}
 \title{Judgment of Line Orientation}
 \usage{
-jlo(data, .input = NULL, .extra = NULL)
+jlo(data, .by = NULL, .input = NULL, .extra = NULL)
 }
 \arguments{
 \item{data}{Raw data of class \code{data.frame}.}
+
+\item{.by}{The column name(s) in \code{data} used to be grouped by. If set to
+\code{NULL} (default), all data will be treated as from one subject and there
+will be no grouping columns in the value returned.}
 
 \item{.input, .extra}{Each is a \code{\link[=list]{list()}} containing all the input variable
 names and special values for certain variables. See more in the details
 section.}
 }
 \value{
-A \link[tibble:tibble-package]{tibble} contains following values:
+An object with the same class as \code{data} contains following values:
+
 \item{nc}{Count of correct responses.}
+
 \item{mean_ang_err}{Mean of the response angle errors.}
+
 \item{mean_log_err}{Mean of the log-transformed (of base 2) response angle
 errors.}
 }

--- a/man/locmem.Rd
+++ b/man/locmem.Rd
@@ -5,23 +5,31 @@
 \alias{locmem2}
 \title{Location Memory}
 \usage{
-locmem(data, .input = NULL, .extra = NULL)
+locmem(data, .by = NULL, .input = NULL, .extra = NULL)
 
-locmem2(data, .input = NULL, .extra = NULL)
+locmem2(data, .by = NULL, .input = NULL, .extra = NULL)
 }
 \arguments{
 \item{data}{Raw data of class \code{data.frame}.}
+
+\item{.by}{The column name(s) in \code{data} used to be grouped by. If set to
+\code{NULL} (default), all data will be treated as from one subject and there
+will be no grouping columns in the value returned.}
 
 \item{.input, .extra}{Each is a \code{\link[=list]{list()}} containing all the input variable
 names and special values for certain variables. See more in the details
 section.}
 }
 \value{
-A \link[tibble:tibble-package]{tibble} contains following values:
+An object with the same class as \code{data} contains following values:
+
 \item{nc_loc}{Count of correct responses for location.}
+
 \item{mean_dist_err}{Mean of the response distance errors.}
+
 \item{mean_log_err}{Mean of the log-transformed (of base \eqn{e}) response
 distance errors.}
+
 \item{nc_order}{Count of correct responses for order. For \code{\link[=locmem2]{locmem2()}}
 only.}
 }

--- a/man/london.Rd
+++ b/man/london.Rd
@@ -4,20 +4,25 @@
 \alias{london}
 \title{London Tower}
 \usage{
-london(data, .input = NULL, .extra = NULL)
+london(data, .by = NULL, .input = NULL, .extra = NULL)
 }
 \arguments{
 \item{data}{Raw data of class \code{data.frame}.}
+
+\item{.by}{The column name(s) in \code{data} used to be grouped by. If set to
+\code{NULL} (default), all data will be treated as from one subject and there
+will be no grouping columns in the value returned.}
 
 \item{.input, .extra}{Each is a \code{\link[=list]{list()}} containing all the input variable
 names and special values for certain variables. See more in the details
 section.}
 }
 \value{
-A \link[tibble:tibble-package]{tibble} contains following values:
-\item{total_score}{Total score defined by the game itself.}
-\item{mean_level}{Mean level reached.}
-\item{level_score}{Sum of mean score (a ratio) for each level.}
+An object with the same class as \code{data} contains following values:
+
+\item{prop_perfect}{Proportion of responses with minimal moves.}
+
+\item{mrt_init}{Mean initial response time.}
 }
 \description{
 A classical test on problem solving.

--- a/man/multisense.Rd
+++ b/man/multisense.Rd
@@ -4,20 +4,28 @@
 \alias{multisense}
 \title{Multiple Sensory Integration}
 \usage{
-multisense(data, .input = NULL, .extra = NULL)
+multisense(data, .by = NULL, .input = NULL, .extra = NULL)
 }
 \arguments{
 \item{data}{Raw data of class \code{data.frame}.}
+
+\item{.by}{The column name(s) in \code{data} used to be grouped by. If set to
+\code{NULL} (default), all data will be treated as from one subject and there
+will be no grouping columns in the value returned.}
 
 \item{.input, .extra}{Each is a \code{\link[=list]{list()}} containing all the input variable
 names and special values for certain variables. See more in the details
 section.}
 }
 \value{
-A \link[tibble:tibble-package]{tibble} contains following values:
+An object with the same class as \code{data} contains following values:
+
 \item{mrt_image}{Mean reaction time of Image stimuli.}
+
 \item{mrt_sound}{Mean reaction time of Sound stimuli.}
+
 \item{mrt_mixed}{Mean reaction time of Mixed stimuli.}
+
 \item{mrt_mixadv}{Mean reaction decrease of Mixed stimuli compared to other
 two types of stimuli.}
 }

--- a/man/nback.Rd
+++ b/man/nback.Rd
@@ -5,19 +5,23 @@
 \alias{dualnback}
 \title{N Back Paradigm}
 \usage{
-nback(data, .input = NULL, .extra = NULL)
+nback(data, .by = NULL, .input = NULL, .extra = NULL)
 
-dualnback(data, .input = NULL, .extra = NULL)
+dualnback(data, .by = NULL, .input = NULL, .extra = NULL)
 }
 \arguments{
 \item{data}{Raw data of class \code{data.frame}.}
+
+\item{.by}{The column name(s) in \code{data} used to be grouped by. If set to
+\code{NULL} (default), all data will be treated as from one subject and there
+will be no grouping columns in the value returned.}
 
 \item{.input, .extra}{Each is a \code{\link[=list]{list()}} containing all the input variable
 names and special values for certain variables. See more in the details
 section.}
 }
 \value{
-A \link[tibble:tibble-package]{tibble} contains following values (tripled
+An object with the same class as \code{data} contains following values (tripled
 for dual n-back):
 
 \item{pc}{Percentage of correct responses.}

--- a/man/nle.Rd
+++ b/man/nle.Rd
@@ -4,18 +4,24 @@
 \alias{nle}
 \title{Number Line Estimation}
 \usage{
-nle(data, .input = NULL, .extra = NULL)
+nle(data, .by = NULL, .input = NULL, .extra = NULL)
 }
 \arguments{
 \item{data}{Raw data of class \code{data.frame}.}
+
+\item{.by}{The column name(s) in \code{data} used to be grouped by. If set to
+\code{NULL} (default), all data will be treated as from one subject and there
+will be no grouping columns in the value returned.}
 
 \item{.input, .extra}{Each is a \code{\link[=list]{list()}} containing all the input variable
 names and special values for certain variables. See more in the details
 section.}
 }
 \value{
-A \link[tibble:tibble-package]{tibble} contains following values:
+An object with the same class as \code{data} contains following values:
+
 \item{mean_abs_err}{Mean absolute error.}
+
 \item{mean_log_err}{Mean log absolute error.}
 }
 \description{

--- a/man/nsymncmp.Rd
+++ b/man/nsymncmp.Rd
@@ -4,19 +4,26 @@
 \alias{nsymncmp}
 \title{Non-symbolic Number Comparison}
 \usage{
-nsymncmp(data, .input = NULL, .extra = NULL)
+nsymncmp(data, .by = NULL, .input = NULL, .extra = NULL)
 }
 \arguments{
 \item{data}{Raw data of class \code{data.frame}.}
+
+\item{.by}{The column name(s) in \code{data} used to be grouped by. If set to
+\code{NULL} (default), all data will be treated as from one subject and there
+will be no grouping columns in the value returned.}
 
 \item{.input, .extra}{Each is a \code{\link[=list]{list()}} containing all the input variable
 names and special values for certain variables. See more in the details
 section.}
 }
 \value{
-A \link[tibble:tibble-package]{tibble} contains following values:
+An object with the same class as \code{data} contains following values:
+
 \item{pc}{Percentage of correct responses.}
+
 \item{mrt}{Mean reaction time.}
+
 \item{w}{Weber fraction.}
 }
 \description{

--- a/man/racer.Rd
+++ b/man/racer.Rd
@@ -4,17 +4,21 @@
 \alias{racer}
 \title{NeuroRacer Modified}
 \usage{
-racer(data, .input = NULL, .extra = NULL)
+racer(data, .by = NULL, .input = NULL, .extra = NULL)
 }
 \arguments{
 \item{data}{Raw data of class \code{data.frame}.}
+
+\item{.by}{The column name(s) in \code{data} used to be grouped by. If set to
+\code{NULL} (default), all data will be treated as from one subject and there
+will be no grouping columns in the value returned.}
 
 \item{.input, .extra}{Each is a \code{\link[=list]{list()}} containing all the input variable
 names and special values for certain variables. See more in the details
 section.}
 }
 \value{
-A \link[tibble:tibble-package]{tibble} contains following values:
+An object with the same class as \code{data} contains following values:
 
 \item{mean_score}{Mean overlap score.}
 

--- a/man/rapm.Rd
+++ b/man/rapm.Rd
@@ -4,17 +4,21 @@
 \alias{rapm}
 \title{Raven's Advanced Progressive Matrices}
 \usage{
-rapm(data, .input = NULL, .extra = NULL)
+rapm(data, .by = NULL, .input = NULL, .extra = NULL)
 }
 \arguments{
 \item{data}{Raw data of class \code{data.frame}.}
+
+\item{.by}{The column name(s) in \code{data} used to be grouped by. If set to
+\code{NULL} (default), all data will be treated as from one subject and there
+will be no grouping columns in the value returned.}
 
 \item{.input, .extra}{Each is a \code{\link[=list]{list()}} containing all the input variable
 names and special values for certain variables. See more in the details
 section.}
 }
 \value{
-A \link[tibble:tibble-package]{tibble} contains following values:
+An object with the same class as \code{data} contains following values:
 
 \item{nc_prac}{Number of correct items for set I.}
 

--- a/man/refframe.Rd
+++ b/man/refframe.Rd
@@ -4,17 +4,21 @@
 \alias{refframe}
 \title{Spatial Reference Frame}
 \usage{
-refframe(data, .input = NULL, .extra = NULL)
+refframe(data, .by = NULL, .input = NULL, .extra = NULL)
 }
 \arguments{
 \item{data}{Raw data of class \code{data.frame}.}
+
+\item{.by}{The column name(s) in \code{data} used to be grouped by. If set to
+\code{NULL} (default), all data will be treated as from one subject and there
+will be no grouping columns in the value returned.}
 
 \item{.input, .extra}{Each is a \code{\link[=list]{list()}} containing all the input variable
 names and special values for certain variables. See more in the details
 section.}
 }
 \value{
-A \link[tibble:tibble-package]{tibble} contains following values:
+An object with the same class as \code{data} contains following values:
 \item{mean_dist_err_allo/mean_dist_err_ego}{Mean of the response distance
 errors for allocentric and egocentric conditions respectively.}
 \item{mean_log_err_allo/mean_log_err_ego}{Mean of the log-transformed (of

--- a/man/reinf.Rd
+++ b/man/reinf.Rd
@@ -4,17 +4,21 @@
 \alias{reinf}
 \title{Probability Reinforcement Learning}
 \usage{
-reinf(data, .input = NULL, .extra = NULL)
+reinf(data, .by = NULL, .input = NULL, .extra = NULL)
 }
 \arguments{
 \item{data}{Raw data of class \code{data.frame}.}
+
+\item{.by}{The column name(s) in \code{data} used to be grouped by. If set to
+\code{NULL} (default), all data will be treated as from one subject and there
+will be no grouping columns in the value returned.}
 
 \item{.input, .extra}{Each is a \code{\link[=list]{list()}} containing all the input variable
 names and special values for certain variables. See more in the details
 section.}
 }
 \value{
-A \link[tibble:tibble-package]{tibble} contains following values:
+An object with the same class as \code{data} contains following values:
 
 \item{pc_approach}{The percent of correct for approach trials.}
 

--- a/man/rt.Rd
+++ b/man/rt.Rd
@@ -6,25 +6,29 @@
 \alias{srt}
 \title{Reaction Times}
 \usage{
-crt(data, .input = NULL, .extra = NULL)
+crt(data, .by = NULL, .input = NULL, .extra = NULL)
 
-srt(data, .input = NULL, .extra = NULL)
+srt(data, .by = NULL, .input = NULL, .extra = NULL)
 }
 \arguments{
 \item{data}{Raw data of class \code{data.frame}.}
+
+\item{.by}{The column name(s) in \code{data} used to be grouped by. If set to
+\code{NULL} (default), all data will be treated as from one subject and there
+will be no grouping columns in the value returned.}
 
 \item{.input, .extra}{Each is a \code{\link[=list]{list()}} containing all the input variable
 names and special values for certain variables. See more in the details
 section.}
 }
 \value{
-A \link[tibble:tibble-package]{tibble} contains following values:
+An object with the same class as \code{data} contains following values:
+
+\item{nc}{Count of correct responses. Only for \code{\link[=crt]{crt()}}.}
 
 \item{mrt}{Mean reaction time.}
 
 \item{rtsd}{Standard deviation of reaction times.}
-
-\item{nc}{Count of correct responses. Only for \code{\link[=crt]{crt()}}.}
 
 \item{ies}{Inverse efficiency score. Only for \code{\link[=crt]{crt()}}.}
 

--- a/man/span.Rd
+++ b/man/span.Rd
@@ -4,17 +4,21 @@
 \alias{span}
 \title{Span (spatial or verbal)}
 \usage{
-span(data, .input = NULL, .extra = NULL)
+span(data, .by = NULL, .input = NULL, .extra = NULL)
 }
 \arguments{
 \item{data}{Raw data of class \code{data.frame}.}
+
+\item{.by}{The column name(s) in \code{data} used to be grouped by. If set to
+\code{NULL} (default), all data will be treated as from one subject and there
+will be no grouping columns in the value returned.}
 
 \item{.input, .extra}{Each is a \code{\link[=list]{list()}} containing all the input variable
 names and special values for certain variables. See more in the details
 section.}
 }
 \value{
-A \link[tibble:tibble-package]{tibble} contains following values:
+An object with the same class as \code{data} contains following values:
 
 \item{nc}{Count of correct responses.}
 

--- a/man/staircase.Rd
+++ b/man/staircase.Rd
@@ -4,17 +4,21 @@
 \alias{staircase}
 \title{Threshold estimation from staircase method}
 \usage{
-staircase(data, .input = NULL, .extra = NULL)
+staircase(data, .by = NULL, .input = NULL, .extra = NULL)
 }
 \arguments{
 \item{data}{Raw data of class \code{data.frame}.}
+
+\item{.by}{The column name(s) in \code{data} used to be grouped by. If set to
+\code{NULL} (default), all data will be treated as from one subject and there
+will be no grouping columns in the value returned.}
 
 \item{.input, .extra}{Each is a \code{\link[=list]{list()}} containing all the input variable
 names and special values for certain variables. See more in the details
 section.}
 }
 \value{
-A \link[tibble:tibble-package]{tibble} contains following values:
+An object with the same class as \code{data} contains following values:
 
 \item{thresh_peak_valley}{The mean threshold of peaks and valleys.}
 

--- a/man/stopsignal.Rd
+++ b/man/stopsignal.Rd
@@ -4,10 +4,14 @@
 \alias{stopsignal}
 \title{Stop Signal Paradigm}
 \usage{
-stopsignal(data, .input = NULL, .extra = NULL)
+stopsignal(data, .by = NULL, .input = NULL, .extra = NULL)
 }
 \arguments{
 \item{data}{Raw data of class \code{data.frame}.}
+
+\item{.by}{The column name(s) in \code{data} used to be grouped by. If set to
+\code{NULL} (default), all data will be treated as from one subject and there
+will be no grouping columns in the value returned.}
 
 \item{.input, .extra}{Each is a \code{\link[=list]{list()}} containing all the input variable
 names and special values for certain variables. See more in the details
@@ -15,10 +19,17 @@ section.}
 }
 \value{
 A \link[tibble:tibble-package]{tibble} with the following variables:
+
 \item{pc_all}{Percent of correct for all the responses.}
+
 \item{pc_go}{Percent of correct for the go trials only.}
+
 \item{pc_stop}{Percent of correct for the stop trials only.}
+
 \item{rt_nth}{Percentile go reaction time (ms) based on \code{pc_stop}.}
+
+\item{mean_ssd}{Mean of stop signal delay (ms).}
+
 \item{ssrt}{Stop signal reaction time (ms).}
 }
 \description{

--- a/man/switch-congruence.Rd
+++ b/man/switch-congruence.Rd
@@ -7,14 +7,18 @@
 \alias{switchcost}
 \title{Task Switching and Stroop-like paradigm}
 \usage{
-complexswitch(data, .input = NULL, .extra = NULL)
+complexswitch(data, .by = NULL, .input = NULL, .extra = NULL)
 
-congeff(data, .input = NULL, .extra = NULL)
+congeff(data, .by = NULL, .input = NULL, .extra = NULL)
 
-switchcost(data, .input = NULL, .extra = NULL)
+switchcost(data, .by = NULL, .input = NULL, .extra = NULL)
 }
 \arguments{
 \item{data}{Raw data of class \code{data.frame}.}
+
+\item{.by}{The column name(s) in \code{data} used to be grouped by. If set to
+\code{NULL} (default), all data will be treated as from one subject and there
+will be no grouping columns in the value returned.}
 
 \item{.input, .extra}{Each is a \code{\link[=list]{list()}} containing all the input variable
 names and special values for certain variables. See more in the details

--- a/man/symncmp.Rd
+++ b/man/symncmp.Rd
@@ -4,19 +4,26 @@
 \alias{symncmp}
 \title{Symbolic Number Comparison}
 \usage{
-symncmp(data, .input = NULL, .extra = NULL)
+symncmp(data, .by = NULL, .input = NULL, .extra = NULL)
 }
 \arguments{
 \item{data}{Raw data of class \code{data.frame}.}
+
+\item{.by}{The column name(s) in \code{data} used to be grouped by. If set to
+\code{NULL} (default), all data will be treated as from one subject and there
+will be no grouping columns in the value returned.}
 
 \item{.input, .extra}{Each is a \code{\link[=list]{list()}} containing all the input variable
 names and special values for certain variables. See more in the details
 section.}
 }
 \value{
-A \link[tibble:tibble-package]{tibble} contains following values:
+An object with the same class as \code{data} contains following values:
+
 \item{pc}{Percentage of correct responses.}
+
 \item{mrt}{Mean reaction time.}
+
 \item{dist_eff}{Distance effect.}
 }
 \description{

--- a/man/synwin.Rd
+++ b/man/synwin.Rd
@@ -4,17 +4,21 @@
 \alias{synwin}
 \title{SynWin Test}
 \usage{
-synwin(data, .input = NULL, .extra = NULL)
+synwin(data, .by = NULL, .input = NULL, .extra = NULL)
 }
 \arguments{
 \item{data}{Raw data of class \code{data.frame}.}
+
+\item{.by}{The column name(s) in \code{data} used to be grouped by. If set to
+\code{NULL} (default), all data will be treated as from one subject and there
+will be no grouping columns in the value returned.}
 
 \item{.input, .extra}{Each is a \code{\link[=list]{list()}} containing all the input variable
 names and special values for certain variables. See more in the details
 section.}
 }
 \value{
-A \link[tibble:tibble-package]{tibble} contains following values:
+An object with the same class as \code{data} contains following values:
 
 \item{score_total}{Total score. Sum of the three sub-tests.}
 

--- a/tests/testthat/_snaps/bart.md
+++ b/tests/testthat/_snaps/bart.md
@@ -6,7 +6,7 @@
         "class": {
           "type": "character",
           "attributes": {},
-          "value": ["data.frame"]
+          "value": ["tbl_df", "tbl", "data.frame"]
         },
         "row.names": {
           "type": "integer",
@@ -34,6 +34,51 @@
           "type": "integer",
           "attributes": {},
           "value": [2]
+        }
+      ]
+    }
+
+# Works with grouping variable
+
+    {
+      "type": "list",
+      "attributes": {
+        "class": {
+          "type": "character",
+          "attributes": {},
+          "value": ["tbl_df", "tbl", "data.frame"]
+        },
+        "row.names": {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        "names": {
+          "type": "character",
+          "attributes": {},
+          "value": ["id", "mean_pumps", "mean_pumps_raw", "num_explosion"]
+        }
+      },
+      "value": [
+        {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [10, 10]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [10, 10]
+        },
+        {
+          "type": "integer",
+          "attributes": {},
+          "value": [2, 2]
         }
       ]
     }

--- a/tests/testthat/_snaps/bps.md
+++ b/tests/testthat/_snaps/bps.md
@@ -3,20 +3,20 @@
     {
       "type": "list",
       "attributes": {
-        "class": {
+        "names": {
           "type": "character",
           "attributes": {},
-          "value": ["tbl_df", "tbl", "data.frame"]
+          "value": ["pc", "p_sim_foil", "p_sim_lure", "p_sim_target", "bps_score"]
         },
         "row.names": {
           "type": "integer",
           "attributes": {},
           "value": [1]
         },
-        "names": {
+        "class": {
           "type": "character",
           "attributes": {},
-          "value": ["pc", "p_sim_foil", "p_sim_lure", "p_sim_target", "bps_score"]
+          "value": ["tbl_df", "tbl", "data.frame"]
         }
       },
       "value": [
@@ -28,12 +28,12 @@
         {
           "type": "double",
           "attributes": {},
-          "value": [0.4]
+          "value": [0.35]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [0.3]
+          "value": [0.4]
         },
         {
           "type": "double",
@@ -43,7 +43,62 @@
         {
           "type": "double",
           "attributes": {},
-          "value": [-0.1]
+          "value": [0.05]
+        }
+      ]
+    }
+
+# Works with grouping variable
+
+    {
+      "type": "list",
+      "attributes": {
+        "names": {
+          "type": "character",
+          "attributes": {},
+          "value": ["id", "pc", "p_sim_foil", "p_sim_lure", "p_sim_target", "bps_score"]
+        },
+        "row.names": {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        "class": {
+          "type": "character",
+          "attributes": {},
+          "value": ["tbl_df", "tbl", "data.frame"]
+        }
+      },
+      "value": [
+        {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.36666667, 0.31666667]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.35, 0.3]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.4, 0.3]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.25, 0.25]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.05, 0]
         }
       ]
     }

--- a/tests/testthat/_snaps/calc_spd_acc.md
+++ b/tests/testthat/_snaps/calc_spd_acc.md
@@ -16,7 +16,7 @@
         "names": {
           "type": "character",
           "attributes": {},
-          "value": ["nc", "pc", "mrt", "rtsd", "ies", "rcs", "lisas"]
+          "value": ["nc", "pc", "pcsd", "mrt", "mrt_all", "rtsd", "ies", "rcs", "lisas"]
         }
       },
       "value": [
@@ -33,7 +33,17 @@
         {
           "type": "double",
           "attributes": {},
+          "value": [0.51298918]
+        },
+        {
+          "type": "double",
+          "attributes": {},
           "value": [2.44307232]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [1.49729309]
         },
         {
           "type": "double",
@@ -76,7 +86,7 @@
         "names": {
           "type": "character",
           "attributes": {},
-          "value": ["nc", "pc", "mrt", "rtsd", "ies", "rcs", "lisas"]
+          "value": ["nc", "pc", "pcsd", "mrt", "mrt_all", "rtsd", "ies", "rcs", "lisas"]
         }
       },
       "value": [
@@ -93,7 +103,17 @@
         {
           "type": "double",
           "attributes": {},
+          "value": [0]
+        },
+        {
+          "type": "double",
+          "attributes": {},
           "value": ["NaN"]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.55151387]
         },
         {
           "type": "double",
@@ -136,7 +156,7 @@
         "names": {
           "type": "character",
           "attributes": {},
-          "value": ["nc", "pc", "mrt", "rtsd", "ies", "rcs", "lisas"]
+          "value": ["nc", "pc", "pcsd", "mrt", "mrt_all", "rtsd", "ies", "rcs", "lisas"]
         }
       },
       "value": [
@@ -149,6 +169,16 @@
           "type": "double",
           "attributes": {},
           "value": [1]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [2.44307232]
         },
         {
           "type": "double",

--- a/tests/testthat/_snaps/complexswitch.md
+++ b/tests/testthat/_snaps/complexswitch.md
@@ -3,182 +3,372 @@
     {
       "type": "list",
       "attributes": {
-        "class": {
+        "names": {
           "type": "character",
           "attributes": {},
-          "value": ["tbl_df", "tbl", "data.frame"]
+          "value": ["pc", "mrt", "switch_cost_pc", "switch_cost_mrt", "switch_cost_ies", "switch_cost_rcs", "switch_cost_lisas", "pc_switch", "pc_repeat", "mrt_switch", "mrt_repeat", "ies_switch", "ies_repeat", "rcs_switch", "rcs_repeat", "lisas_switch", "lisas_repeat", "cong_eff_pc", "cong_eff_mrt", "cong_eff_ies", "cong_eff_rcs", "cong_eff_lisas", "pc_inc", "pc_con", "mrt_inc", "mrt_con", "ies_inc", "ies_con", "rcs_inc", "rcs_con", "lisas_inc", "lisas_con"]
         },
         "row.names": {
           "type": "integer",
           "attributes": {},
           "value": [1]
         },
-        "names": {
+        "class": {
           "type": "character",
           "attributes": {},
-          "value": ["pc", "mrt", "switch_cost_pc", "switch_cost_mrt", "switch_cost_ies", "switch_cost_rcs", "switch_cost_lisas", "pc_switch", "pc_repeat", "mrt_switch", "mrt_repeat", "ies_switch", "ies_repeat", "rcs_switch", "rcs_repeat", "lisas_switch", "lisas_repeat", "cong_eff_pc", "cong_eff_mrt", "cong_eff_ies", "cong_eff_rcs", "cong_eff_lisas", "pc_inc", "pc_con", "mrt_inc", "mrt_con", "ies_inc", "ies_con", "rcs_inc", "rcs_con", "lisas_inc", "lisas_con"]
+          "value": ["tbl_df", "tbl", "data.frame"]
         }
       },
       "value": [
         {
           "type": "double",
           "attributes": {},
-          "value": [0.48648649]
+          "value": [0.40540541]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [1.00900179]
+          "value": [1.03299589]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [0.23888889]
+          "value": [0.00318979]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [-0.23715523]
+          "value": [0.21138486]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [0.51397747]
+          "value": [0.51840278]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [0.02428783]
+          "value": [0.05594639]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [-0.27964963]
+          "value": [0.290917]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [0.36111111]
+          "value": [0.42105263]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [0.6]
+          "value": [0.42424242]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [0.82465607]
+          "value": [1.12775462]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [1.0618113]
+          "value": [0.91636976]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [2.28366297]
+          "value": [2.67841722]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [1.7696855]
+          "value": [2.16001444]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [0.49357054]
+          "value": [0.4601855]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [0.51785837]
+          "value": [0.51613189]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [1.50222506]
+          "value": [2.19142257]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [1.78187469]
+          "value": [1.90050557]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [0.10989011]
+          "value": [0.15147059]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [0.21209719]
+          "value": [0.22376322]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [0.93328771]
+          "value": [1.5646066]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [0.11705779]
+          "value": [0.1949131]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [0.55800818]
+          "value": [0.47028608]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [0.42857143]
+          "value": [0.32352941]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [0.53846154]
+          "value": [0.475]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [1.13272515]
+          "value": [1.10945127]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [0.92062796]
+          "value": [0.88568805]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [2.64302536]
+          "value": [3.42921302]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [1.70973765]
+          "value": [1.86460642]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [0.43143311]
+          "value": [0.39340528]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [0.54849089]
+          "value": [0.58831839]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [2.12365441]
+          "value": [2.23527826]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [1.56564623]
+          "value": [1.76499219]
+        }
+      ]
+    }
+
+# Works with grouping variable
+
+    {
+      "type": "list",
+      "attributes": {
+        "names": {
+          "type": "character",
+          "attributes": {},
+          "value": ["id", "pc", "mrt", "switch_cost_pc", "switch_cost_mrt", "switch_cost_ies", "switch_cost_rcs", "switch_cost_lisas", "pc_switch", "pc_repeat", "mrt_switch", "mrt_repeat", "ies_switch", "ies_repeat", "rcs_switch", "rcs_repeat", "lisas_switch", "lisas_repeat", "cong_eff_pc", "cong_eff_mrt", "cong_eff_ies", "cong_eff_rcs", "cong_eff_lisas", "pc_inc", "pc_con", "mrt_inc", "mrt_con", "ies_inc", "ies_con", "rcs_inc", "rcs_con", "lisas_inc", "lisas_con"]
+        },
+        "row.names": {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        "class": {
+          "type": "character",
+          "attributes": {},
+          "value": ["tbl_df", "tbl", "data.frame"]
+        }
+      },
+      "value": [
+        {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.40540541, 0.41489362]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [1.03299589, 0.83630915]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.00318979, -0.09558824]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.21138486, -0.45252395]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.51840278, -1.56451712]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.05594639, -0.22875344]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.290917, -0.80703719]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.42105263, 0.47058824]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.42424242, 0.375]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [1.12775462, 0.66052909]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.91636976, 1.11305303]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [2.67841722, 1.40362431]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [2.16001444, 2.96814142]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.4601855, 0.63496946]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.51613189, 0.40621602]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [2.19142257, 1.42115896]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [1.90050557, 2.22819615]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.15147059, 0.09931973]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.22376322, -0.34011295]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [1.5646066, -0.31620165]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.1949131, 0.04207083]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.47028608, -0.73362084]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.32352941, 0.36734694]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.475, 0.46666667]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [1.10945127, 0.71217929]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.88568805, 1.05229224]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [3.42921302, 1.9387103]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [1.86460642, 2.25491195]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.39340528, 0.47614418]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.58831839, 0.51821501]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [2.23527826, 1.3738003]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [1.76499219, 2.10742114]
         }
       ]
     }

--- a/tests/testthat/_snaps/congeff.md
+++ b/tests/testthat/_snaps/congeff.md
@@ -3,32 +3,32 @@
     {
       "type": "list",
       "attributes": {
-        "class": {
+        "names": {
           "type": "character",
           "attributes": {},
-          "value": ["tbl_df", "tbl", "data.frame"]
+          "value": ["pc", "mrt", "cong_eff_pc", "cong_eff_mrt", "cong_eff_ies", "cong_eff_rcs", "cong_eff_lisas", "pc_inc", "pc_con", "mrt_inc", "mrt_con", "ies_inc", "ies_con", "rcs_inc", "rcs_con", "lisas_inc", "lisas_con"]
         },
         "row.names": {
           "type": "integer",
           "attributes": {},
           "value": [1]
         },
-        "names": {
+        "class": {
           "type": "character",
           "attributes": {},
-          "value": ["pc", "mrt", "cong_eff_pc", "cong_eff_mrt", "cong_eff_ies", "cong_eff_rcs", "cong_eff_lisas", "pc_inc", "pc_con", "mrt_inc", "mrt_con", "ies_inc", "ies_con", "rcs_inc", "rcs_con", "lisas_inc", "lisas_con"]
+          "value": ["tbl_df", "tbl", "data.frame"]
         }
       },
       "value": [
         {
           "type": "double",
           "attributes": {},
-          "value": [0.4]
+          "value": [0.65]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [0.57717104]
+          "value": [1.18822212]
         },
         {
           "type": "double",
@@ -38,72 +38,187 @@
         {
           "type": "double",
           "attributes": {},
-          "value": [-0.38734149]
+          "value": [-0.2359454]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [-1.14255532]
+          "value": [-0.51529535]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [-0.02466904]
+          "value": [-0.18172322]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [-0.59381334]
+          "value": [-0.91303287]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [0.41666667]
+          "value": [0.66666667]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [0.375]
+          "value": [0.625]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [0.41116754]
+          "value": [1.37782701]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [0.79850903]
+          "value": [1.61377242]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [0.9868021]
+          "value": [2.06674052]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [2.12935742]
+          "value": [2.58203586]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [0.64977541]
+          "value": [0.64688051]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [0.62510637]
+          "value": [0.46515729]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [0.93346276]
+          "value": [2.05795214]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [1.5272761]
+          "value": [2.97098502]
+        }
+      ]
+    }
+
+# Works with grouping variable
+
+    {
+      "type": "list",
+      "attributes": {
+        "names": {
+          "type": "character",
+          "attributes": {},
+          "value": ["id", "pc", "mrt", "cong_eff_pc", "cong_eff_mrt", "cong_eff_ies", "cong_eff_rcs", "cong_eff_lisas", "pc_inc", "pc_con", "mrt_inc", "mrt_con", "ies_inc", "ies_con", "rcs_inc", "rcs_con", "lisas_inc", "lisas_con"]
+        },
+        "row.names": {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        "class": {
+          "type": "character",
+          "attributes": {},
+          "value": ["tbl_df", "tbl", "data.frame"]
+        }
+      },
+      "value": [
+        {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.65, 0.65]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [1.18822212, 1.13717124]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [-0.04166667, 0.16666667]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [-0.2359454, 0.09944621]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [-0.51529535, 0.58328809]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [-0.18172322, -0.03772485]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [-0.91303287, 0.07092664]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.66666667, 0.58333333]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.625, 0.75]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [1.37782701, 1.18306949]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [1.61377242, 1.08362328]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [2.06674052, 2.02811912]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [2.58203586, 1.44483104]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.64688051, 0.55743769]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.46515729, 0.51971284]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [2.05795214, 1.71137251]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [2.97098502, 1.64044587]
         }
       ]
     }

--- a/tests/testthat/_snaps/countcorrect.md
+++ b/tests/testthat/_snaps/countcorrect.md
@@ -1,82 +1,82 @@
-# Default behavior
+# Works for different types of input
 
     {
       "type": "list",
       "attributes": {
-        "class": {
+        "names": {
           "type": "character",
           "attributes": {},
-          "value": ["tbl_df", "tbl", "data.frame"]
+          "value": ["nc"]
         },
         "row.names": {
           "type": "integer",
           "attributes": {},
           "value": [1]
         },
-        "names": {
+        "class": {
           "type": "character",
           "attributes": {},
-          "value": ["nc"]
+          "value": ["tbl_df", "tbl", "data.frame"]
         }
       },
       "value": [
         {
           "type": "integer",
           "attributes": {},
-          "value": [8]
+          "value": [15]
         }
       ]
     }
 
-# Works for character acc input
+---
 
     {
       "type": "list",
       "attributes": {
-        "class": {
+        "names": {
           "type": "character",
           "attributes": {},
-          "value": ["tbl_df", "tbl", "data.frame"]
+          "value": ["nc"]
         },
         "row.names": {
           "type": "integer",
           "attributes": {},
           "value": [1]
         },
-        "names": {
+        "class": {
           "type": "character",
           "attributes": {},
-          "value": ["nc"]
+          "value": ["tbl_df", "tbl", "data.frame"]
         }
       },
       "value": [
         {
           "type": "integer",
           "attributes": {},
-          "value": [12]
+          "value": [76]
         }
       ]
     }
 
-# Works with pre-calculated ncorrect input
+---
 
     {
       "type": "list",
       "attributes": {
-        "class": {
+        "names": {
           "type": "character",
           "attributes": {},
-          "value": ["tbl_df", "tbl", "data.frame"]
+          "value": ["nc"]
         },
         "row.names": {
           "type": "integer",
           "attributes": {},
           "value": [1]
         },
-        "names": {
+        "class": {
           "type": "character",
           "attributes": {},
-          "value": ["nc"]
+          "value": ["tbl_df", "tbl", "data.frame"]
         }
       },
       "value": [
@@ -84,6 +84,111 @@
           "type": "double",
           "attributes": {},
           "value": [10]
+        }
+      ]
+    }
+
+# Works with grouping variable
+
+    {
+      "type": "list",
+      "attributes": {
+        "names": {
+          "type": "character",
+          "attributes": {},
+          "value": ["id", "nc"]
+        },
+        "row.names": {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        "class": {
+          "type": "character",
+          "attributes": {},
+          "value": ["tbl_df", "tbl", "data.frame"]
+        }
+      },
+      "value": [
+        {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        {
+          "type": "integer",
+          "attributes": {},
+          "value": [15, 12]
+        }
+      ]
+    }
+
+---
+
+    {
+      "type": "list",
+      "attributes": {
+        "names": {
+          "type": "character",
+          "attributes": {},
+          "value": ["id", "nc"]
+        },
+        "row.names": {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        "class": {
+          "type": "character",
+          "attributes": {},
+          "value": ["tbl_df", "tbl", "data.frame"]
+        }
+      },
+      "value": [
+        {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        {
+          "type": "integer",
+          "attributes": {},
+          "value": [76, 90]
+        }
+      ]
+    }
+
+---
+
+    {
+      "type": "list",
+      "attributes": {
+        "names": {
+          "type": "character",
+          "attributes": {},
+          "value": ["id", "nc"]
+        },
+        "row.names": {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        "class": {
+          "type": "character",
+          "attributes": {},
+          "value": ["tbl_df", "tbl", "data.frame"]
+        }
+      },
+      "value": [
+        {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [10, 10]
         }
       ]
     }

--- a/tests/testthat/_snaps/countcorrect2.md
+++ b/tests/testthat/_snaps/countcorrect2.md
@@ -1,59 +1,129 @@
-# Default behavior
+# Works for different types of input
 
     {
       "type": "list",
       "attributes": {
-        "class": {
+        "names": {
           "type": "character",
           "attributes": {},
-          "value": ["tbl_df", "tbl", "data.frame"]
+          "value": ["nc_cor"]
         },
         "row.names": {
           "type": "integer",
           "attributes": {},
           "value": [1]
         },
-        "names": {
+        "class": {
           "type": "character",
           "attributes": {},
-          "value": ["nc_cor"]
+          "value": ["tbl_df", "tbl", "data.frame"]
         }
       },
       "value": [
         {
           "type": "integer",
           "attributes": {},
-          "value": [-4]
+          "value": [12]
         }
       ]
     }
 
-# Works with pre-calculated ncorrect and nerror input
+---
 
     {
       "type": "list",
       "attributes": {
-        "class": {
+        "names": {
           "type": "character",
           "attributes": {},
-          "value": ["tbl_df", "tbl", "data.frame"]
+          "value": ["nc_cor"]
         },
         "row.names": {
           "type": "integer",
           "attributes": {},
           "value": [1]
         },
-        "names": {
+        "class": {
           "type": "character",
           "attributes": {},
-          "value": ["nc_cor"]
+          "value": ["tbl_df", "tbl", "data.frame"]
         }
       },
       "value": [
         {
           "type": "double",
           "attributes": {},
-          "value": [18]
+          "value": [8]
+        }
+      ]
+    }
+
+# Works with grouping variable
+
+    {
+      "type": "list",
+      "attributes": {
+        "names": {
+          "type": "character",
+          "attributes": {},
+          "value": ["id", "nc_cor"]
+        },
+        "row.names": {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        "class": {
+          "type": "character",
+          "attributes": {},
+          "value": ["tbl_df", "tbl", "data.frame"]
+        }
+      },
+      "value": [
+        {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        {
+          "type": "integer",
+          "attributes": {},
+          "value": [12, 11]
+        }
+      ]
+    }
+
+---
+
+    {
+      "type": "list",
+      "attributes": {
+        "names": {
+          "type": "character",
+          "attributes": {},
+          "value": ["id", "nc_cor"]
+        },
+        "row.names": {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        "class": {
+          "type": "character",
+          "attributes": {},
+          "value": ["tbl_df", "tbl", "data.frame"]
+        }
+      },
+      "value": [
+        {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [8, 8]
         }
       ]
     }

--- a/tests/testthat/_snaps/cpt.md
+++ b/tests/testthat/_snaps/cpt.md
@@ -3,72 +3,112 @@
     {
       "type": "list",
       "attributes": {
-        "class": {
+        "names": {
           "type": "character",
           "attributes": {},
-          "value": ["tbl_df", "tbl", "data.frame"]
+          "value": ["pc", "mrt", "rtsd", "dprime", "commissions", "omissions"]
         },
         "row.names": {
           "type": "integer",
           "attributes": {},
           "value": [1]
         },
+        "class": {
+          "type": "character",
+          "attributes": {},
+          "value": ["tbl_df", "tbl", "data.frame"]
+        }
+      },
+      "value": [
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [1]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [1.34363152]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [1.47114892]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [3.36204386]
+        },
+        {
+          "type": "integer",
+          "attributes": {},
+          "value": [0]
+        },
+        {
+          "type": "integer",
+          "attributes": {},
+          "value": [0]
+        }
+      ]
+    }
+
+# Works with grouping variable
+
+    {
+      "type": "list",
+      "attributes": {
         "names": {
           "type": "character",
           "attributes": {},
-          "value": ["nc", "mrt", "rtsd", "ies", "rcs", "lisas", "dprime", "c", "commissions", "omissions"]
+          "value": ["id", "pc", "mrt", "rtsd", "dprime", "commissions", "omissions"]
+        },
+        "row.names": {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        "class": {
+          "type": "character",
+          "attributes": {},
+          "value": ["tbl_df", "tbl", "data.frame"]
         }
       },
       "value": [
         {
           "type": "integer",
           "attributes": {},
-          "value": [8]
+          "value": [1, 2]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [0.79850903]
+          "value": [1, 0.9]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [0.60347646]
+          "value": [1.34363152, 1.53438086]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [1.99627258]
+          "value": [1.47114892, 1.15924207]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [0.66678013]
-        },
-        {
-          "type": "double",
-          "attributes": {},
-          "value": [1.51889919]
-        },
-        {
-          "type": "double",
-          "attributes": {},
-          "value": [-0.47624429]
-        },
-        {
-          "type": "double",
-          "attributes": {},
-          "value": [0.044094]
+          "value": [3.36204386, 2.16580127]
         },
         {
           "type": "integer",
           "attributes": {},
-          "value": [7]
+          "value": [0, 1]
         },
         {
           "type": "integer",
           "attributes": {},
-          "value": [5]
+          "value": [0, 1]
         }
       ]
     }
@@ -78,27 +118,27 @@
     {
       "type": "list",
       "attributes": {
-        "class": {
+        "names": {
           "type": "character",
           "attributes": {},
-          "value": ["tbl_df", "tbl", "data.frame"]
+          "value": ["pc", "mrt", "rtsd", "dprime", "commissions", "omissions"]
         },
         "row.names": {
           "type": "integer",
           "attributes": {},
           "value": [1]
         },
-        "names": {
+        "class": {
           "type": "character",
           "attributes": {},
-          "value": ["nc", "mrt", "rtsd", "ies", "rcs", "lisas", "dprime", "c", "commissions", "omissions"]
+          "value": ["tbl_df", "tbl", "data.frame"]
         }
       },
       "value": [
         {
-          "type": "integer",
+          "type": "double",
           "attributes": {},
-          "value": [20]
+          "value": [1]
         },
         {
           "type": "double",
@@ -113,27 +153,7 @@
         {
           "type": "double",
           "attributes": {},
-          "value": [1.43868832]
-        },
-        {
-          "type": "double",
-          "attributes": {},
-          "value": [0.69507758]
-        },
-        {
-          "type": "double",
-          "attributes": {},
-          "value": [1.43868832]
-        },
-        {
-          "type": "double",
-          "attributes": {},
           "value": [3.36204386]
-        },
-        {
-          "type": "double",
-          "attributes": {},
-          "value": [0.08780311]
         },
         {
           "type": "integer",

--- a/tests/testthat/_snaps/crt.md
+++ b/tests/testthat/_snaps/crt.md
@@ -3,20 +3,20 @@
     {
       "type": "list",
       "attributes": {
-        "class": {
+        "names": {
           "type": "character",
           "attributes": {},
-          "value": ["tbl_df", "tbl", "data.frame"]
+          "value": ["nc", "mrt", "rtsd", "ies", "rcs", "lisas"]
         },
         "row.names": {
           "type": "integer",
           "attributes": {},
           "value": [1]
         },
-        "names": {
+        "class": {
           "type": "character",
           "attributes": {},
-          "value": ["nc", "mrt", "rtsd", "ies", "rcs", "lisas"]
+          "value": ["tbl_df", "tbl", "data.frame"]
         }
       },
       "value": [
@@ -28,27 +28,87 @@
         {
           "type": "double",
           "attributes": {},
-          "value": [0.67751209]
+          "value": [1.16407176]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [0.56484095]
+          "value": [0.89045377]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [1.69378023]
+          "value": [2.91017939]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [0.53687296]
+          "value": [0.36804972]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [1.36059609]
+          "value": [2.24093193]
+        }
+      ]
+    }
+
+# Works with grouping variable
+
+    {
+      "type": "list",
+      "attributes": {
+        "names": {
+          "type": "character",
+          "attributes": {},
+          "value": ["id", "nc", "mrt", "rtsd", "ies", "rcs", "lisas"]
+        },
+        "row.names": {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        "class": {
+          "type": "character",
+          "attributes": {},
+          "value": ["tbl_df", "tbl", "data.frame"]
+        }
+      },
+      "value": [
+        {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        {
+          "type": "integer",
+          "attributes": {},
+          "value": [16, 26]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [1.16407176, 0.88690383]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.89045377, 0.66131113]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [2.91017939, 1.36446743]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.36804972, 0.84361559]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [2.24093193, 1.36606927]
         }
       ]
     }

--- a/tests/testthat/_snaps/driving.md
+++ b/tests/testthat/_snaps/driving.md
@@ -3,27 +3,62 @@
     {
       "type": "list",
       "attributes": {
-        "class": {
+        "names": {
           "type": "character",
           "attributes": {},
-          "value": ["tbl_df", "tbl", "data.frame"]
+          "value": ["still_ratio"]
         },
         "row.names": {
           "type": "integer",
           "attributes": {},
           "value": [1]
         },
-        "names": {
+        "class": {
           "type": "character",
           "attributes": {},
-          "value": ["still_ratio"]
+          "value": ["tbl_df", "tbl", "data.frame"]
         }
       },
       "value": [
         {
           "type": "double",
           "attributes": {},
-          "value": [0.22503122]
+          "value": [0.27084829]
+        }
+      ]
+    }
+
+# Works with grouping variable
+
+    {
+      "type": "list",
+      "attributes": {
+        "names": {
+          "type": "character",
+          "attributes": {},
+          "value": ["id", "still_ratio"]
+        },
+        "row.names": {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        "class": {
+          "type": "character",
+          "attributes": {},
+          "value": ["tbl_df", "tbl", "data.frame"]
+        }
+      },
+      "value": [
+        {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.27084829, 0.27871196]
         }
       ]
     }

--- a/tests/testthat/_snaps/drm.md
+++ b/tests/testthat/_snaps/drm.md
@@ -43,3 +43,53 @@
       ]
     }
 
+# Works with grouping variable
+
+    {
+      "type": "list",
+      "attributes": {
+        "names": {
+          "type": "character",
+          "attributes": {},
+          "value": ["id", "tm_dprime", "tm_bias", "fm_dprime", "fm_bias"]
+        },
+        "row.names": {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        "class": {
+          "type": "character",
+          "attributes": {},
+          "value": ["tbl_df", "tbl", "data.frame"]
+        }
+      },
+      "value": [
+        {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.16405893, -0.24337666]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.16297676, 0.04074104]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.75093988, -0.16189458]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [-0.13046372, 6.9388939e-17]
+        }
+      ]
+    }
+

--- a/tests/testthat/_snaps/dualnback.md
+++ b/tests/testthat/_snaps/dualnback.md
@@ -3,20 +3,20 @@
     {
       "type": "list",
       "attributes": {
-        "class": {
+        "names": {
           "type": "character",
           "attributes": {},
-          "value": ["tbl_df", "tbl", "data.frame"]
+          "value": ["pc_aud", "pc_both", "pc_vis", "mrt_aud", "mrt_both", "mrt_vis", "ies_aud", "ies_both", "ies_vis", "rcs_aud", "rcs_both", "rcs_vis", "lisas_aud", "lisas_both", "lisas_vis", "dprime_aud", "dprime_both", "dprime_vis"]
         },
         "row.names": {
           "type": "integer",
           "attributes": {},
           "value": [1]
         },
-        "names": {
+        "class": {
           "type": "character",
           "attributes": {},
-          "value": ["pc_aud", "pc_both", "pc_vis", "mrt_aud", "mrt_both", "mrt_vis", "ies_aud", "ies_both", "ies_vis", "rcs_aud", "rcs_both", "rcs_vis", "lisas_aud", "lisas_both", "lisas_vis", "dprime_aud", "dprime_both", "dprime_vis"]
+          "value": ["tbl_df", "tbl", "data.frame"]
         }
       },
       "value": [
@@ -38,62 +38,62 @@
         {
           "type": "double",
           "attributes": {},
-          "value": [0.15578377]
+          "value": [0.36102098]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [0.9779171]
+          "value": [0.33098192]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [1.59451711]
+          "value": [0.30761821]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [0.38945942]
+          "value": [0.90255244]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [2.17314912]
+          "value": [0.73551538]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [3.18903421]
+          "value": [0.61523643]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [0.68364255]
+          "value": [1.13489593]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [0.54153801]
+          "value": [1.48265643]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [0.45144065]
+          "value": [1.96414757]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [0.33447971]
+          "value": [1.24077917]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [2.27520858]
+          "value": [1.00290735]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [2.83767754]
+          "value": [0.84290976]
         },
         {
           "type": "double",
@@ -109,6 +109,126 @@
           "type": "double",
           "attributes": {},
           "value": [0]
+        }
+      ]
+    }
+
+# Works with grouping variable
+
+    {
+      "type": "list",
+      "attributes": {
+        "class": {
+          "type": "character",
+          "attributes": {},
+          "value": ["tbl_df", "tbl", "data.frame"]
+        },
+        "row.names": {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        "names": {
+          "type": "character",
+          "attributes": {},
+          "value": ["id", "pc_aud", "pc_both", "pc_vis", "mrt_aud", "mrt_both", "mrt_vis", "ies_aud", "ies_both", "ies_vis", "rcs_aud", "rcs_both", "rcs_vis", "lisas_aud", "lisas_both", "lisas_vis", "dprime_aud", "dprime_both", "dprime_vis"]
+        }
+      },
+      "value": [
+        {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.4, 0.65]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.45, 0.625]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.5, 0.6]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.36102098, 0.36379006]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.33098192, 0.29318688]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.30761821, 0.21670009]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.90255244, 0.55967701]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.73551538, 0.469099]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.61523643, 0.36116682]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [1.13489593, 2.01679709]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [1.48265643, 1.95815393]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [1.96414757, 1.89835483]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [1.24077917, 0.76613461]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [1.00290735, 0.66695011]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.84290976, 0.53851175]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [-0.45976824, 0.70267324]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [-0.24104039, 0.61684868]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0, 0.47278912]
         }
       ]
     }

--- a/tests/testthat/_snaps/igt.md
+++ b/tests/testthat/_snaps/igt.md
@@ -3,32 +3,72 @@
     {
       "type": "list",
       "attributes": {
-        "class": {
+        "names": {
           "type": "character",
           "attributes": {},
-          "value": ["tbl_df", "tbl", "data.frame"]
+          "value": ["sum_outcome", "perc_good"]
         },
         "row.names": {
           "type": "integer",
           "attributes": {},
           "value": [1]
         },
-        "names": {
+        "class": {
           "type": "character",
           "attributes": {},
-          "value": ["sum_outcome", "perc_good"]
+          "value": ["tbl_df", "tbl", "data.frame"]
         }
       },
       "value": [
         {
           "type": "double",
           "attributes": {},
-          "value": [101600]
+          "value": [103000]
         },
         {
           "type": "double",
           "attributes": {},
           "value": [0.6]
+        }
+      ]
+    }
+
+# Works with grouping variable
+
+    {
+      "type": "list",
+      "attributes": {
+        "names": {
+          "type": "character",
+          "attributes": {},
+          "value": ["id", "sum_outcome", "perc_good"]
+        },
+        "row.names": {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        "class": {
+          "type": "character",
+          "attributes": {},
+          "value": ["tbl_df", "tbl", "data.frame"]
+        }
+      },
+      "value": [
+        {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [103000, 115000]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.6, 0.4875]
         }
       ]
     }

--- a/tests/testthat/_snaps/jlo.md
+++ b/tests/testthat/_snaps/jlo.md
@@ -38,3 +38,48 @@
       ]
     }
 
+# Works with grouping variable
+
+    {
+      "type": "list",
+      "attributes": {
+        "names": {
+          "type": "character",
+          "attributes": {},
+          "value": ["id", "nc", "mean_ang_err", "mean_log_err"]
+        },
+        "row.names": {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        "class": {
+          "type": "character",
+          "attributes": {},
+          "value": ["tbl_df", "tbl", "data.frame"]
+        }
+      },
+      "value": [
+        {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        {
+          "type": "integer",
+          "attributes": {},
+          "value": [0, 0]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [56.25, 52.5]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.67644898, 0.64847183]
+        }
+      ]
+    }
+

--- a/tests/testthat/_snaps/locmem.md
+++ b/tests/testthat/_snaps/locmem.md
@@ -38,3 +38,48 @@
       ]
     }
 
+# Works with grouping variable
+
+    {
+      "type": "list",
+      "attributes": {
+        "names": {
+          "type": "character",
+          "attributes": {},
+          "value": ["id", "nc_loc", "mean_dist_err", "mean_log_err"]
+        },
+        "row.names": {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        "class": {
+          "type": "character",
+          "attributes": {},
+          "value": ["tbl_df", "tbl", "data.frame"]
+        }
+      },
+      "value": [
+        {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        {
+          "type": "integer",
+          "attributes": {},
+          "value": [0, 0]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [5.29306452, 5.15967742]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [1.72903044, 1.70345254]
+        }
+      ]
+    }
+

--- a/tests/testthat/_snaps/locmem2.md
+++ b/tests/testthat/_snaps/locmem2.md
@@ -3,20 +3,20 @@
     {
       "type": "list",
       "attributes": {
-        "class": {
+        "names": {
           "type": "character",
           "attributes": {},
-          "value": ["tbl_df", "tbl", "data.frame"]
+          "value": ["nc_loc", "mean_dist_err", "mean_log_err", "nc_order"]
         },
         "row.names": {
           "type": "integer",
           "attributes": {},
           "value": [1]
         },
-        "names": {
+        "class": {
           "type": "character",
           "attributes": {},
-          "value": ["nc_loc", "mean_dist_err", "mean_log_err", "nc_order"]
+          "value": ["tbl_df", "tbl", "data.frame"]
         }
       },
       "value": [
@@ -28,17 +28,67 @@
         {
           "type": "double",
           "attributes": {},
-          "value": [5.30560976]
+          "value": [4.98268293]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [1.71280301]
+          "value": [1.66734896]
         },
         {
           "type": "integer",
           "attributes": {},
-          "value": [23]
+          "value": [19]
+        }
+      ]
+    }
+
+# Works with grouping variable
+
+    {
+      "type": "list",
+      "attributes": {
+        "names": {
+          "type": "character",
+          "attributes": {},
+          "value": ["id", "nc_loc", "mean_dist_err", "mean_log_err", "nc_order"]
+        },
+        "row.names": {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        "class": {
+          "type": "character",
+          "attributes": {},
+          "value": ["tbl_df", "tbl", "data.frame"]
+        }
+      },
+      "value": [
+        {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        {
+          "type": "integer",
+          "attributes": {},
+          "value": [0, 0]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [4.98268293, 5.2136]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [1.66734896, 1.69871346]
+        },
+        {
+          "type": "integer",
+          "attributes": {},
+          "value": [19, 36]
         }
       ]
     }

--- a/tests/testthat/_snaps/london.md
+++ b/tests/testthat/_snaps/london.md
@@ -3,20 +3,20 @@
     {
       "type": "list",
       "attributes": {
-        "class": {
+        "names": {
           "type": "character",
           "attributes": {},
-          "value": ["tbl_df", "tbl", "data.frame"]
+          "value": ["prop_perfect", "mrt_init"]
         },
         "row.names": {
           "type": "integer",
           "attributes": {},
           "value": [1]
         },
-        "names": {
+        "class": {
           "type": "character",
           "attributes": {},
-          "value": ["prop_perfect", "mrt_init"]
+          "value": ["tbl_df", "tbl", "data.frame"]
         }
       },
       "value": [
@@ -28,7 +28,47 @@
         {
           "type": "double",
           "attributes": {},
-          "value": [9.47182439]
+          "value": [10.29451303]
+        }
+      ]
+    }
+
+# Works with grouping variable
+
+    {
+      "type": "list",
+      "attributes": {
+        "names": {
+          "type": "character",
+          "attributes": {},
+          "value": ["id", "prop_perfect", "mrt_init"]
+        },
+        "row.names": {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        "class": {
+          "type": "character",
+          "attributes": {},
+          "value": ["tbl_df", "tbl", "data.frame"]
+        }
+      },
+      "value": [
+        {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.5, 0.5]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [10.29451303, 7.61933326]
         }
       ]
     }

--- a/tests/testthat/_snaps/multisense.md
+++ b/tests/testthat/_snaps/multisense.md
@@ -43,3 +43,53 @@
       ]
     }
 
+# Works with grouping variable
+
+    {
+      "type": "list",
+      "attributes": {
+        "names": {
+          "type": "character",
+          "attributes": {},
+          "value": ["id", "mrt_image", "mrt_mixed", "mrt_sound", "mrt_mixadv"]
+        },
+        "row.names": {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        "class": {
+          "type": "character",
+          "attributes": {},
+          "value": ["tbl_df", "tbl", "data.frame"]
+        }
+      },
+      "value": [
+        {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.91381962, 1.16790939]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.91838962, 0.88696221]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.6914493, 0.82471921]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [-0.11575517, 0.10935209]
+        }
+      ]
+    }
+

--- a/tests/testthat/_snaps/nback.md
+++ b/tests/testthat/_snaps/nback.md
@@ -3,20 +3,20 @@
     {
       "type": "list",
       "attributes": {
-        "class": {
+        "names": {
           "type": "character",
           "attributes": {},
-          "value": ["tbl_df", "tbl", "data.frame"]
+          "value": ["pc", "mrt", "ies", "rcs", "lisas", "dprime"]
         },
         "row.names": {
           "type": "integer",
           "attributes": {},
           "value": [1]
         },
-        "names": {
+        "class": {
           "type": "character",
           "attributes": {},
-          "value": ["pc", "mrt", "ies", "rcs", "lisas", "dprime"]
+          "value": ["tbl_df", "tbl", "data.frame"]
         }
       },
       "value": [
@@ -28,27 +28,87 @@
         {
           "type": "double",
           "attributes": {},
-          "value": [1.06404785]
+          "value": [0.50886421]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [2.66011963]
+          "value": [1.27216053]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [0.38538427]
+          "value": [0.54579516]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [2.52490057]
+          "value": [1.03113978]
         },
         {
           "type": "double",
           "attributes": {},
           "value": [-0.45976824]
+        }
+      ]
+    }
+
+# Works with grouping variable
+
+    {
+      "type": "list",
+      "attributes": {
+        "names": {
+          "type": "character",
+          "attributes": {},
+          "value": ["id", "pc", "mrt", "ies", "rcs", "lisas", "dprime"]
+        },
+        "row.names": {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        "class": {
+          "type": "character",
+          "attributes": {},
+          "value": ["tbl_df", "tbl", "data.frame"]
+        }
+      },
+      "value": [
+        {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.4, 0.5]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.50886421, 1.14328339]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [1.27216053, 2.28656678]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.54579516, 0.51417618]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [1.03113978, 2.09890284]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [-0.45976824, 0]
         }
       ]
     }

--- a/tests/testthat/_snaps/nle.md
+++ b/tests/testthat/_snaps/nle.md
@@ -23,12 +23,52 @@
         {
           "type": "double",
           "attributes": {},
-          "value": [24.25]
+          "value": [28.75]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [2.95499502]
+          "value": [2.91915827]
+        }
+      ]
+    }
+
+# Works with grouping variable
+
+    {
+      "type": "list",
+      "attributes": {
+        "class": {
+          "type": "character",
+          "attributes": {},
+          "value": ["tbl_df", "tbl", "data.frame"]
+        },
+        "row.names": {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        "names": {
+          "type": "character",
+          "attributes": {},
+          "value": ["id", "mean_abs_err", "mean_log_err"]
+        }
+      },
+      "value": [
+        {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [28.75, 23.05]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [2.91915827, 2.66233123]
         }
       ]
     }

--- a/tests/testthat/_snaps/nsymncmp.md
+++ b/tests/testthat/_snaps/nsymncmp.md
@@ -3,20 +3,20 @@
     {
       "type": "list",
       "attributes": {
-        "class": {
+        "names": {
           "type": "character",
           "attributes": {},
-          "value": ["tbl_df", "tbl", "data.frame"]
+          "value": ["pc", "mrt", "w"]
         },
         "row.names": {
           "type": "integer",
           "attributes": {},
           "value": [1]
         },
-        "names": {
+        "class": {
           "type": "character",
           "attributes": {},
-          "value": ["pc", "mrt", "w"]
+          "value": ["tbl_df", "tbl", "data.frame"]
         }
       },
       "value": [
@@ -34,6 +34,51 @@
           "type": "double",
           "attributes": {},
           "value": [0.16505778]
+        }
+      ]
+    }
+
+# Works with grouping variable
+
+    {
+      "type": "list",
+      "attributes": {
+        "names": {
+          "type": "character",
+          "attributes": {},
+          "value": ["id", "pc", "mrt", "w"]
+        },
+        "row.names": {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        "class": {
+          "type": "character",
+          "attributes": {},
+          "value": ["tbl_df", "tbl", "data.frame"]
+        }
+      },
+      "value": [
+        {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.75, 0.75]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.97298127, 0.83058348]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.16505082, 0.16505778]
         }
       ]
     }

--- a/tests/testthat/_snaps/racer.md
+++ b/tests/testthat/_snaps/racer.md
@@ -3,20 +3,20 @@
     {
       "type": "list",
       "attributes": {
-        "class": {
+        "names": {
           "type": "character",
           "attributes": {},
-          "value": ["data.frame"]
+          "value": ["mean_score", "dprime"]
         },
         "row.names": {
           "type": "integer",
           "attributes": {},
           "value": [1]
         },
-        "names": {
+        "class": {
           "type": "character",
           "attributes": {},
-          "value": ["mean_score", "dprime"]
+          "value": ["tbl_df", "tbl", "data.frame"]
         }
       },
       "value": [
@@ -29,6 +29,46 @@
           "type": "double",
           "attributes": {},
           "value": [0.88491814]
+        }
+      ]
+    }
+
+# Works with grouping variable
+
+    {
+      "type": "list",
+      "attributes": {
+        "names": {
+          "type": "character",
+          "attributes": {},
+          "value": ["id", "mean_score", "dprime"]
+        },
+        "row.names": {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        "class": {
+          "type": "character",
+          "attributes": {},
+          "value": ["tbl_df", "tbl", "data.frame"]
+        }
+      },
+      "value": [
+        {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.05, 0.05]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.88491814, 0.88491814]
         }
       ]
     }

--- a/tests/testthat/_snaps/rapm.md
+++ b/tests/testthat/_snaps/rapm.md
@@ -38,3 +38,48 @@
       ]
     }
 
+# Works with grouping variable
+
+    {
+      "type": "list",
+      "attributes": {
+        "names": {
+          "type": "character",
+          "attributes": {},
+          "value": ["id", "nc_prac", "nc_test", "nc_total"]
+        },
+        "row.names": {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        "class": {
+          "type": "character",
+          "attributes": {},
+          "value": ["tbl_df", "tbl", "data.frame"]
+        }
+      },
+      "value": [
+        {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        {
+          "type": "integer",
+          "attributes": {},
+          "value": [9, 11]
+        },
+        {
+          "type": "integer",
+          "attributes": {},
+          "value": [31, 29]
+        },
+        {
+          "type": "integer",
+          "attributes": {},
+          "value": [40, 40]
+        }
+      ]
+    }
+

--- a/tests/testthat/_snaps/refframe.md
+++ b/tests/testthat/_snaps/refframe.md
@@ -43,3 +43,53 @@
       ]
     }
 
+# Works with grouping variable
+
+    {
+      "type": "list",
+      "attributes": {
+        "names": {
+          "type": "character",
+          "attributes": {},
+          "value": ["id", "mean_dist_err_both", "mean_dist_err_NA", "mean_log_err_both", "mean_log_err_NA"]
+        },
+        "row.names": {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        "class": {
+          "type": "character",
+          "attributes": {},
+          "value": ["tbl_df", "tbl", "data.frame"]
+        }
+      },
+      "value": [
+        {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [101.91047849, 102.9245442]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [101.91047849, 102.9245442]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [4.37524342, 4.43191503]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [4.37524342, 4.43191503]
+        }
+      ]
+    }
+

--- a/tests/testthat/_snaps/reinf.md
+++ b/tests/testthat/_snaps/reinf.md
@@ -1,22 +1,22 @@
-# Default behavior
+# Default behavior works
 
     {
       "type": "list",
       "attributes": {
-        "class": {
+        "names": {
           "type": "character",
           "attributes": {},
-          "value": ["tbl_df", "tbl", "data.frame"]
+          "value": ["pc_approach", "pc_avoid", "pc_learn", "pc_test"]
         },
         "row.names": {
           "type": "integer",
           "attributes": {},
           "value": [1]
         },
-        "names": {
+        "class": {
           "type": "character",
           "attributes": {},
-          "value": ["pc_approach", "pc_avoid", "pc_learn", "pc_test"]
+          "value": ["tbl_df", "tbl", "data.frame"]
         }
       },
       "value": [
@@ -39,6 +39,56 @@
           "type": "double",
           "attributes": {},
           "value": [0.4]
+        }
+      ]
+    }
+
+# Works with grouping variable
+
+    {
+      "type": "list",
+      "attributes": {
+        "names": {
+          "type": "character",
+          "attributes": {},
+          "value": ["id", "pc_approach", "pc_avoid", "pc_learn", "pc_test"]
+        },
+        "row.names": {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        "class": {
+          "type": "character",
+          "attributes": {},
+          "value": ["tbl_df", "tbl", "data.frame"]
+        }
+      },
+      "value": [
+        {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.4, 0.6]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.4, 0.7]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.4, 0.65]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.4, 0.65]
         }
       ]
     }

--- a/tests/testthat/_snaps/span.md
+++ b/tests/testthat/_snaps/span.md
@@ -3,27 +3,27 @@
     {
       "type": "list",
       "attributes": {
-        "class": {
+        "names": {
           "type": "character",
           "attributes": {},
-          "value": ["tbl_df", "tbl", "data.frame"]
+          "value": ["nc", "max_span", "mean_span_pcu", "mean_span_anu"]
         },
         "row.names": {
           "type": "integer",
           "attributes": {},
           "value": [1]
         },
-        "names": {
+        "class": {
           "type": "character",
           "attributes": {},
-          "value": ["nc", "max_span", "mean_span_pcu", "mean_span_anu"]
+          "value": ["tbl_df", "tbl", "data.frame"]
         }
       },
       "value": [
         {
           "type": "double",
           "attributes": {},
-          "value": [73]
+          "value": [77]
         },
         {
           "type": "double",
@@ -33,12 +33,62 @@
         {
           "type": "double",
           "attributes": {},
-          "value": [9.45555556]
+          "value": [9.67222222]
         },
         {
           "type": "double",
           "attributes": {},
           "value": [9.58333333]
+        }
+      ]
+    }
+
+# Works with grouping variable
+
+    {
+      "type": "list",
+      "attributes": {
+        "names": {
+          "type": "character",
+          "attributes": {},
+          "value": ["id", "nc", "max_span", "mean_span_pcu", "mean_span_anu"]
+        },
+        "row.names": {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        "class": {
+          "type": "character",
+          "attributes": {},
+          "value": ["tbl_df", "tbl", "data.frame"]
+        }
+      },
+      "value": [
+        {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [77, 94]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [10, 12]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [9.67222222, 11.67460317]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [9.58333333, 11.66666667]
         }
       ]
     }

--- a/tests/testthat/_snaps/srt.md
+++ b/tests/testthat/_snaps/srt.md
@@ -33,3 +33,43 @@
       ]
     }
 
+# Works with grouping variable
+
+    {
+      "type": "list",
+      "attributes": {
+        "names": {
+          "type": "character",
+          "attributes": {},
+          "value": ["id", "mrt", "rtsd"]
+        },
+        "row.names": {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        "class": {
+          "type": "character",
+          "attributes": {},
+          "value": ["tbl_df", "tbl", "data.frame"]
+        }
+      },
+      "value": [
+        {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.84262221, 0.99292785]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.83119415, 0.46972995]
+        }
+      ]
+    }
+

--- a/tests/testthat/_snaps/staircase.md
+++ b/tests/testthat/_snaps/staircase.md
@@ -1,22 +1,22 @@
-# Can deal with grouping
+# Default behavior works
 
     {
       "type": "list",
       "attributes": {
-        "class": {
+        "names": {
           "type": "character",
           "attributes": {},
-          "value": ["tbl_df", "tbl", "data.frame"]
+          "value": ["thresh_peak_valley", "thresh_last_block"]
         },
         "row.names": {
           "type": "integer",
           "attributes": {},
           "value": [1]
         },
-        "names": {
+        "class": {
           "type": "character",
           "attributes": {},
-          "value": ["thresh_peak_valley", "thresh_last_block"]
+          "value": ["tbl_df", "tbl", "data.frame"]
         }
       },
       "value": [
@@ -29,6 +29,46 @@
           "type": "double",
           "attributes": {},
           "value": [140]
+        }
+      ]
+    }
+
+# Works with grouping variable
+
+    {
+      "type": "list",
+      "attributes": {
+        "names": {
+          "type": "character",
+          "attributes": {},
+          "value": ["id", "thresh_peak_valley", "thresh_last_block"]
+        },
+        "row.names": {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        "class": {
+          "type": "character",
+          "attributes": {},
+          "value": ["tbl_df", "tbl", "data.frame"]
+        }
+      },
+      "value": [
+        {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [147.08333333, 150.38461538]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [140, 148.75]
         }
       ]
     }

--- a/tests/testthat/_snaps/stopsignal.md
+++ b/tests/testthat/_snaps/stopsignal.md
@@ -3,27 +3,27 @@
     {
       "type": "list",
       "attributes": {
-        "class": {
+        "names": {
           "type": "character",
           "attributes": {},
-          "value": ["tbl_df", "tbl", "data.frame"]
+          "value": ["pc_all", "pc_go", "pc_stop", "rt_nth", "mean_ssd", "ssrt"]
         },
         "row.names": {
           "type": "integer",
           "attributes": {},
           "value": [1]
         },
-        "names": {
+        "class": {
           "type": "character",
           "attributes": {},
-          "value": ["pc_all", "pc_go", "pc_stop", "rt_nth", "ssrt"]
+          "value": ["tbl_df", "tbl", "data.frame"]
         }
       },
       "value": [
         {
           "type": "double",
           "attributes": {},
-          "value": [0.65625]
+          "value": [0.7]
         },
         {
           "type": "double",
@@ -33,17 +33,82 @@
         {
           "type": "double",
           "attributes": {},
-          "value": [0.475]
+          "value": [0.65]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [622.81005452]
+          "value": [296.36795739]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [163.71914543]
+          "value": [308.92857143]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [-12.56061404]
+        }
+      ]
+    }
+
+# Works with grouping variable
+
+    {
+      "type": "list",
+      "attributes": {
+        "names": {
+          "type": "character",
+          "attributes": {},
+          "value": ["id", "pc_all", "pc_go", "pc_stop", "rt_nth", "mean_ssd", "ssrt"]
+        },
+        "row.names": {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        "class": {
+          "type": "character",
+          "attributes": {},
+          "value": ["tbl_df", "tbl", "data.frame"]
+        }
+      },
+      "value": [
+        {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.7, 0.6625]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.71666667, 0.68333333]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.65, 0.6]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [296.36795739, 400.94416334]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [308.92857143, 341.98717949]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [-12.56061404, 58.95698386]
         }
       ]
     }

--- a/tests/testthat/_snaps/sumscore.md
+++ b/tests/testthat/_snaps/sumscore.md
@@ -3,27 +3,62 @@
     {
       "type": "list",
       "attributes": {
-        "class": {
+        "names": {
           "type": "character",
           "attributes": {},
-          "value": ["tbl_df", "tbl", "data.frame"]
+          "value": ["nc_score"]
         },
         "row.names": {
           "type": "integer",
           "attributes": {},
           "value": [1]
         },
-        "names": {
+        "class": {
           "type": "character",
           "attributes": {},
-          "value": ["nc_score"]
+          "value": ["tbl_df", "tbl", "data.frame"]
         }
       },
       "value": [
         {
           "type": "double",
           "attributes": {},
-          "value": [57]
+          "value": [25]
+        }
+      ]
+    }
+
+# Works with grouping variable
+
+    {
+      "type": "list",
+      "attributes": {
+        "names": {
+          "type": "character",
+          "attributes": {},
+          "value": ["id", "nc_score"]
+        },
+        "row.names": {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        "class": {
+          "type": "character",
+          "attributes": {},
+          "value": ["tbl_df", "tbl", "data.frame"]
+        }
+      },
+      "value": [
+        {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [25, 32]
         }
       ]
     }

--- a/tests/testthat/_snaps/sumweighted.md
+++ b/tests/testthat/_snaps/sumweighted.md
@@ -1,29 +1,64 @@
-# Default behavior works
+# Works as expect
 
     {
       "type": "list",
       "attributes": {
-        "class": {
+        "names": {
           "type": "character",
           "attributes": {},
-          "value": ["tbl_df", "tbl", "data.frame"]
+          "value": ["nc_weighted"]
         },
         "row.names": {
           "type": "integer",
           "attributes": {},
           "value": [1]
         },
-        "names": {
+        "class": {
           "type": "character",
           "attributes": {},
-          "value": ["nc_weighted"]
+          "value": ["tbl_df", "tbl", "data.frame"]
         }
       },
       "value": [
         {
           "type": "integer",
           "attributes": {},
-          "value": [18]
+          "value": [79]
+        }
+      ]
+    }
+
+# Works with grouping variable
+
+    {
+      "type": "list",
+      "attributes": {
+        "names": {
+          "type": "character",
+          "attributes": {},
+          "value": ["id", "nc_weighted"]
+        },
+        "row.names": {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        "class": {
+          "type": "character",
+          "attributes": {},
+          "value": ["tbl_df", "tbl", "data.frame"]
+        }
+      },
+      "value": [
+        {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        {
+          "type": "integer",
+          "attributes": {},
+          "value": [79, 90]
         }
       ]
     }

--- a/tests/testthat/_snaps/switchcost.md
+++ b/tests/testthat/_snaps/switchcost.md
@@ -3,107 +3,222 @@
     {
       "type": "list",
       "attributes": {
-        "class": {
+        "names": {
           "type": "character",
           "attributes": {},
-          "value": ["tbl_df", "tbl", "data.frame"]
+          "value": ["pc", "mrt", "switch_cost_pc", "switch_cost_mrt", "switch_cost_ies", "switch_cost_rcs", "switch_cost_lisas", "pc_switch", "pc_repeat", "mrt_switch", "mrt_repeat", "ies_switch", "ies_repeat", "rcs_switch", "rcs_repeat", "lisas_switch", "lisas_repeat"]
         },
         "row.names": {
           "type": "integer",
           "attributes": {},
           "value": [1]
         },
-        "names": {
+        "class": {
           "type": "character",
           "attributes": {},
-          "value": ["pc", "mrt", "switch_cost_pc", "switch_cost_mrt", "switch_cost_ies", "switch_cost_rcs", "switch_cost_lisas", "pc_switch", "pc_repeat", "mrt_switch", "mrt_repeat", "ies_switch", "ies_repeat", "rcs_switch", "rcs_repeat", "lisas_switch", "lisas_repeat"]
+          "value": ["tbl_df", "tbl", "data.frame"]
         }
       },
       "value": [
         {
           "type": "double",
           "attributes": {},
-          "value": [0.48333333]
+          "value": [0.525]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [0.88642683]
+          "value": [0.93774369]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [0.09515152]
+          "value": [-0.06]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [-0.11422644]
+          "value": [-0.10482157]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [0.14345092]
+          "value": [-0.40179966]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [0.11398947]
+          "value": [-0.0225474]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [-0.14990089]
+          "value": [-0.47025281]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [0.42]
+          "value": [0.56]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [0.51515152]
+          "value": [0.5]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [0.83038788]
+          "value": [0.89673044]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [0.94461432]
+          "value": [1.00155201]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [1.97711401]
+          "value": [1.60130435]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [1.83366309]
+          "value": [2.00310401]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [0.43593002]
+          "value": [0.61044147]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [0.54991949]
+          "value": [0.58789408]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [1.47481371]
+          "value": [1.55124]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [1.6247146]
+          "value": [2.02149282]
+        }
+      ]
+    }
+
+# Works with grouping variable
+
+    {
+      "type": "list",
+      "attributes": {
+        "names": {
+          "type": "character",
+          "attributes": {},
+          "value": ["id", "pc", "mrt", "switch_cost_pc", "switch_cost_mrt", "switch_cost_ies", "switch_cost_rcs", "switch_cost_lisas", "pc_switch", "pc_repeat", "mrt_switch", "mrt_repeat", "ies_switch", "ies_repeat", "rcs_switch", "rcs_repeat", "lisas_switch", "lisas_repeat"]
+        },
+        "row.names": {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        "class": {
+          "type": "character",
+          "attributes": {},
+          "value": ["tbl_df", "tbl", "data.frame"]
+        }
+      },
+      "value": [
+        {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.525, 0.44166667]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.93774369, 0.69227237]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [-0.06, -0.12068966]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [-0.10482157, -0.06214812]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [-0.40179966, -0.59817302]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [-0.0225474, -0.11517035]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [-0.47025281, -0.55634542]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.56, 0.5]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.5, 0.37931034]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.89673044, 0.68251537]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [1.00155201, 0.74466349]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [1.60130435, 1.36503074]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [2.00310401, 1.96320375]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.61044147, 0.60658919]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.58789408, 0.49141884]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [1.55124, 1.17033375]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [2.02149282, 1.72667917]
         }
       ]
     }

--- a/tests/testthat/_snaps/symncmp.md
+++ b/tests/testthat/_snaps/symncmp.md
@@ -3,20 +3,20 @@
     {
       "type": "list",
       "attributes": {
-        "class": {
+        "names": {
           "type": "character",
           "attributes": {},
-          "value": ["tbl_df", "tbl", "data.frame"]
+          "value": ["pc", "mrt", "dist_eff"]
         },
         "row.names": {
           "type": "integer",
           "attributes": {},
           "value": [1]
         },
-        "names": {
+        "class": {
           "type": "character",
           "attributes": {},
-          "value": ["pc", "mrt", "dist_eff"]
+          "value": ["tbl_df", "tbl", "data.frame"]
         }
       },
       "value": [
@@ -28,12 +28,57 @@
         {
           "type": "double",
           "attributes": {},
-          "value": [1.00750004]
+          "value": [0.82780474]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [-28.23318592]
+          "value": [38.13685714]
+        }
+      ]
+    }
+
+# Works with grouping variable
+
+    {
+      "type": "list",
+      "attributes": {
+        "names": {
+          "type": "character",
+          "attributes": {},
+          "value": ["id", "pc", "mrt", "dist_eff"]
+        },
+        "row.names": {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        "class": {
+          "type": "character",
+          "attributes": {},
+          "value": ["tbl_df", "tbl", "data.frame"]
+        }
+      },
+      "value": [
+        {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.54166667, 0.47222222]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.82780474, 1.0493525]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [38.13685714, -159.67939139]
         }
       ]
     }

--- a/tests/testthat/_snaps/synwin.md
+++ b/tests/testthat/_snaps/synwin.md
@@ -1,44 +1,94 @@
-# Can deal with grouping
+# Default behavior works
 
     {
       "type": "list",
       "attributes": {
-        "class": {
+        "names": {
           "type": "character",
           "attributes": {},
-          "value": ["tbl_df", "tbl", "data.frame"]
+          "value": ["score_total", "score_aud", "score_mem", "score_vis"]
         },
         "row.names": {
           "type": "integer",
           "attributes": {},
           "value": [1]
         },
-        "names": {
+        "class": {
           "type": "character",
           "attributes": {},
-          "value": ["score_total", "score_aud", "score_mem", "score_vis"]
+          "value": ["tbl_df", "tbl", "data.frame"]
         }
       },
       "value": [
         {
           "type": "double",
           "attributes": {},
-          "value": [64.25]
+          "value": [59.65]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [13.25]
+          "value": [12.75]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [13]
+          "value": [14]
         },
         {
           "type": "double",
           "attributes": {},
-          "value": [38]
+          "value": [32.9]
+        }
+      ]
+    }
+
+# Works with grouping variable
+
+    {
+      "type": "list",
+      "attributes": {
+        "names": {
+          "type": "character",
+          "attributes": {},
+          "value": ["id", "score_total", "score_aud", "score_mem", "score_vis"]
+        },
+        "row.names": {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        "class": {
+          "type": "character",
+          "attributes": {},
+          "value": ["tbl_df", "tbl", "data.frame"]
+        }
+      },
+      "value": [
+        {
+          "type": "integer",
+          "attributes": {},
+          "value": [1, 2]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [59.65, 50.55]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [12.75, 8.25]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [14, 16.5]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [32.9, 25.8]
         }
       ]
     }

--- a/tests/testthat/test-bart.R
+++ b/tests/testthat/test-bart.R
@@ -1,7 +1,13 @@
+data <- tibble(
+  id = rep(1:2, each = 5),
+  nhit = rep(10, 10),
+  feedback = rep(c(rep(1, 3), rep(0, 2)), 2)
+)
+
 test_that("Works as expected", {
-  data <- data.frame(
-    nhit = rep(10, 5),
-    feedback = c(rep(1, 3), rep(0, 2))
-  )
-  expect_snapshot_value(bart(data), style = "json2")
+  expect_snapshot_value(bart(filter(data, id == 1)), style = "json2")
+})
+
+test_that("Works with grouping variable", {
+  expect_snapshot_value(bart(data, .by = "id"), style = "json2")
 })

--- a/tests/testthat/test-bps.R
+++ b/tests/testthat/test-bps.R
@@ -1,35 +1,43 @@
-test_that("Default behavior works", {
-  data <- withr::with_seed(
-    1,
+data <- withr::with_seed(
+  1,
+  expand_grid(
+    id = 1:2,
     tibble::tibble(
       phase = c("learn", "test"),
       n = c(40, 60)
-    ) |>
-      uncount(n, .id = "trial") |>
-      mutate(
-        type = case_when(
-          phase == "learn" ~ NA_character_,
-          (trial + 1) %% 3 == 0 ~ "lure",
-          (trial + 1) %% 3 == 1 ~ "foil",
-          (trial + 1) %% 3 == 2 ~ "target"
-        ),
-        resp = if_else(
-          phase == "learn",
-          sample(c("left", "right"), n(), replace = TRUE),
-          sample(c("old", "similar", "new"), n(), replace = TRUE)
-        ),
-        acc = case_when(
-          phase == "learn" ~ NA_integer_,
-          (type == "target" & resp == "old") |
-            (type == "foil" & resp == "new") |
-            (type == "lure" & resp == "similar") ~ 1L,
-          TRUE ~ 0L
-        ),
-        rt = rexp(n(), 0.001)
-      )
-  )
+    )
+  ) |>
+    uncount(n, .id = "trial") |>
+    mutate(
+      type = case_when(
+        phase == "learn" ~ NA_character_,
+        (trial + 1) %% 3 == 0 ~ "lure",
+        (trial + 1) %% 3 == 1 ~ "foil",
+        (trial + 1) %% 3 == 2 ~ "target"
+      ),
+      resp = if_else(
+        phase == "learn",
+        sample(c("left", "right"), n(), replace = TRUE),
+        sample(c("old", "similar", "new"), n(), replace = TRUE)
+      ),
+      acc = case_when(
+        phase == "learn" ~ NA_integer_,
+        (type == "target" & resp == "old") |
+          (type == "foil" & resp == "new") |
+          (type == "lure" & resp == "similar") ~ 1L,
+        TRUE ~ 0L
+      ),
+      rt = rexp(n(), 0.001)
+    )
+)
+
+test_that("Default behavior works", {
   expect_snapshot_value(
-    bps(data),
+    bps(filter(data, id == 1)),
     style = "json2"
   )
+})
+
+test_that("Works with grouping variable", {
+  expect_snapshot_value(bps(data, .by = "id"), style = "json2")
 })

--- a/tests/testthat/test-congeff.R
+++ b/tests/testthat/test-congeff.R
@@ -1,28 +1,40 @@
+data <- withr::with_seed(
+  1,
+  expand_grid(
+    id = 1:2,
+    trial = 1:20
+  ) |>
+    mutate(
+      type = sample(
+        c("incongruent", "congruent"),
+        n(),
+        replace = TRUE
+      ),
+      acc = sample(c(0, 1), n(), replace = TRUE),
+      rt = rexp(n(), 0.001)
+    )
+)
+
 test_that("Default behavior works", {
-  data <- withr::with_seed(
-    1,
-    tibble(trial = 1:20) |>
-      mutate(
-        type = sample(
-          c("incongruent", "congruent"),
-          n(),
-          replace = TRUE
-        ),
-        acc = sample(c(0, 1), n(), replace = TRUE),
-        rt = rexp(n(), 0.001)
-      )
-  )
   expect_snapshot_value(
-    congeff(data),
+    congeff(filter(data, id == 1)),
     style = "json2",
-    tolerance = 0.01
+    tolerance = 1e-5
+  )
+})
+
+test_that("Works with grouping variable", {
+  expect_snapshot_value(
+    congeff(data, .by = "id"),
+    style = "json2",
+    tolerance = 1e-5
   )
 })
 
 test_that("Works when condition missing", {
   data_miss_cond <- withr::with_seed(
     1,
-    tibble::tibble(
+    tibble(
       trial = 1:100,
       type = "incongruent"
     ) |>

--- a/tests/testthat/test-countcorrect2.R
+++ b/tests/testthat/test-countcorrect2.R
@@ -1,19 +1,37 @@
-test_that("Default behavior", {
-  data <- withr::with_seed(
-    1,
-    tibble(trial = 1:20) |>
-      mutate(acc = sample(0:1, n(), replace = TRUE))
+n_subject <- 2
+data_acc <- withr::with_seed(
+  1,
+  tibble::tibble(
+    id = seq_len(n_subject),
+    n = sample(10:20, n_subject, replace = TRUE)
+  ) |>
+    uncount(n, .id = "trial") |>
+    mutate(acc = sample(c(0, 1), n(), replace = TRUE, prob = c(0.1, 0.9)))
+)
+data_ncorrect <- withr::with_seed(
+  1,
+  tibble(id = seq_len(n_subject)) |>
+    mutate(ncorrect = 10, nerror = 2)
+)
+
+test_that("Works for different types of input", {
+  expect_snapshot_value(
+    countcorrect2(filter(data_acc, id == 1)),
+    style = "json2"
   )
   expect_snapshot_value(
-    countcorrect2(data),
+    countcorrect2(filter(data_ncorrect, id == 1)),
     style = "json2"
   )
 })
 
-test_that("Works with pre-calculated ncorrect and nerror input", {
-  data <- tibble(ncorrect = 20, nerror = 2)
+test_that("Works with grouping variable", {
   expect_snapshot_value(
-    countcorrect2(data),
+    countcorrect2(data_acc, .by = "id"),
+    style = "json2"
+  )
+  expect_snapshot_value(
+    countcorrect2(data_ncorrect, .by = "id"),
     style = "json2"
   )
 })

--- a/tests/testthat/test-cpt.R
+++ b/tests/testthat/test-cpt.R
@@ -1,20 +1,32 @@
+n_subject <- 2
+data <- withr::with_seed(
+  1,
+  expand_grid(
+    id = seq_len(n_subject),
+    trial = 1:20
+  ) |>
+    mutate(
+      type = sample(
+        c("nontarget", "target"),
+        n(),
+        replace = TRUE
+      ),
+      acc = sample(c(0, 1), n(), replace = TRUE, prob = c(0.1, 0.9)),
+      rt = rexp(n(), 0.001)
+    )
+)
 
 test_that("Default behavior works", {
-  data <- withr::with_seed(
-    1,
-    tibble(trial = 1:20) |>
-      mutate(
-        type = sample(
-          c("nontarget", "target"),
-          n(),
-          replace = TRUE
-        ),
-        acc = sample(c(0, 1), n(), replace = TRUE),
-        rt = rexp(n(), 0.001)
-      )
-  )
   expect_snapshot_value(
-    cpt(data),
+    cpt(filter(data, id == 1)),
+    style = "json2",
+    tolerance = 1e-5
+  )
+})
+
+test_that("Works with grouping variable", {
+  expect_snapshot_value(
+    cpt(data, .by = "id"),
     style = "json2",
     tolerance = 1e-5
   )

--- a/tests/testthat/test-crt.R
+++ b/tests/testthat/test-crt.R
@@ -1,14 +1,25 @@
+data <- withr::with_seed(
+  1,
+  expand_grid(
+    id = 1:2,
+    trial = 1:40
+  ) |>
+    mutate(
+      acc = sample(c(0, 1), n(), replace = TRUE),
+      rt = rexp(n(), 0.001)
+    )
+)
+
 test_that("Default behavior works", {
-  data <- withr::with_seed(
-    1,
-    tibble(trial = 1:40) |>
-      mutate(
-        acc = sample(c(0, 1), n(), replace = TRUE),
-        rt = rexp(n(), 0.001)
-      )
-  )
   expect_snapshot_value(
-    crt(data),
+    crt(filter(data, id == 1)),
+    style = "json2"
+  )
+})
+
+test_that("Works with grouping variable", {
+  expect_snapshot_value(
+    crt(data, .by = "id"),
     style = "json2"
   )
 })

--- a/tests/testthat/test-driving.R
+++ b/tests/testthat/test-driving.R
@@ -1,34 +1,46 @@
-test_that("Default behavior works", {
-  data <- withr::with_seed(
-    1,
-    tibble(trial = 1:8) |>
-      mutate(
-        yellowdur = runif(n(), 3000, 15000),
-        stilldurlist = purrr::map(
-          yellowdur,
-          ~ {
-            repeat {
-              n <- sample(1:10, 1)
-              dur <- rexp(n, 0.001)
-              if (sum(dur) < .x) break
-            }
-            round(dur)
+data <- withr::with_seed(
+  1,
+  expand_grid(
+    id = 1:2,
+    trial = 1:8
+  ) |>
+    mutate(
+      yellowdur = runif(n(), 3000, 15000),
+      stilldurlist = purrr::map(
+        yellowdur,
+        ~ {
+          repeat {
+            n <- sample(1:10, 1)
+            dur <- rexp(n, 0.001)
+            if (sum(dur) < .x) break
           }
-        ),
-        stilldur = purrr::map_chr(
-          stilldurlist,
-          ~ stringr::str_c(.x, collapse = "-")
-        ),
-        stilllight = purrr::map_chr(
-          stilldurlist,
-          ~ sample(c("yellow", "green"), length(.x), replace = TRUE) |>
-            stringr::str_c(collapse = "-")
-        )
-      ) |>
-      select(-stilldurlist)
-  )
+          round(dur)
+        }
+      ),
+      stilldur = purrr::map_chr(
+        stilldurlist,
+        ~ stringr::str_c(.x, collapse = "-")
+      ),
+      stilllight = purrr::map_chr(
+        stilldurlist,
+        ~ sample(c("yellow", "green"), length(.x), replace = TRUE) |>
+          stringr::str_c(collapse = "-")
+      )
+    ) |>
+    select(-stilldurlist)
+)
+
+test_that("Default behavior works", {
   expect_snapshot_value(
-    driving(data),
+    driving(filter(data, id == 1)),
+    style = "json2",
+    tolerance = 1e-5
+  )
+})
+
+test_that("Works with grouping variable", {
+  expect_snapshot_value(
+    driving(data, .by = "id"),
     style = "json2",
     tolerance = 1e-5
   )

--- a/tests/testthat/test-drm.R
+++ b/tests/testthat/test-drm.R
@@ -1,30 +1,39 @@
-set.seed(1)
-n_subject <- 5
-
-
-test_that("Default behavior works", {
-  data <- withr::with_seed(
-    1,
+n_subject <- 2
+data <- withr::with_seed(
+  1,
+  expand_grid(
+    id = seq_len(n_subject),
     tibble::tribble(
       ~type, ~n,
       "filler", 10,
       "foil", 30,
       "lure", 30,
       "old", 30
-    ) |>
-      uncount(n) |>
-      mutate(
-        resp = sample(c("new", "old"), n(), replace = TRUE),
-        acc = ifelse(
-          (type == "old" & resp == "old") |
-            (type %in% c("foil", "lure") & resp == "new"),
-          1, 0
-        ),
-        rt = rexp(n(), 0.001)
-      )
-  )
+    )
+  ) |>
+    uncount(n) |>
+    mutate(
+      resp = sample(c("new", "old"), n(), replace = TRUE),
+      acc = ifelse(
+        (type == "old" & resp == "old") |
+          (type %in% c("foil", "lure") & resp == "new"),
+        1, 0
+      ),
+      rt = rexp(n(), 0.001)
+    )
+)
+
+test_that("Default behavior works", {
   expect_snapshot_value(
-    drm(data),
+    drm(filter(data, id == 1)),
+    style = "json2",
+    tolerance = 1e-5
+  )
+})
+
+test_that("Works with grouping variable", {
+  expect_snapshot_value(
+    drm(data, .by = "id"),
     style = "json2",
     tolerance = 1e-5
   )

--- a/tests/testthat/test-dualnback.R
+++ b/tests/testthat/test-dualnback.R
@@ -1,32 +1,42 @@
-test_that("Default behavior works", {
-  data <- withr::with_seed(
-    1,
-    expand_grid(
-      dual = c("aud", "vis"),
-      tibble::tibble(
-        type = c("filler", "same", "different"),
-        n = c(1, 10, 10)
+data <- withr::with_seed(
+  1,
+  expand_grid(
+    id = 1:2,
+    dual = c("aud", "vis"),
+    tibble::tibble(
+      type = c("filler", "same", "different"),
+      n = c(1, 10, 10)
+    )
+  ) |>
+    uncount(n) |>
+    group_by(id, dual) |>
+    mutate(trial = row_number()) |>
+    ungroup() |>
+    mutate(
+      acc = sample(c(0, 1), n(), replace = TRUE),
+      rt = if_else(
+        type == "filler" | xor(type == "same", acc == 1),
+        0, rexp(n(), 0.001)
       )
     ) |>
-      uncount(n) |>
-      group_by(dual) |>
-      mutate(trial = row_number()) |>
-      ungroup() |>
-      mutate(
-        acc = sample(c(0, 1), n(), replace = TRUE),
-        rt = if_else(
-          type == "filler" | xor(type == "same", acc == 1),
-          0, rexp(n(), 0.001)
-        )
-      ) |>
-      pivot_wider(
-        names_from = dual,
-        values_from = c(type, acc, rt),
-        names_sep = ""
-      )
-  )
+    pivot_wider(
+      names_from = dual,
+      values_from = c(type, acc, rt),
+      names_sep = ""
+    )
+)
+
+test_that("Default behavior works", {
   expect_snapshot_value(
-    dualnback(data),
+    dualnback(filter(data, id == 1)),
+    style = "json2",
+    tolerance = 1e-5
+  )
+})
+
+test_that("Works with grouping variable", {
+  expect_snapshot_value(
+    dualnback(data, .by = "id"),
     style = "json2",
     tolerance = 1e-5
   )

--- a/tests/testthat/test-igt.R
+++ b/tests/testthat/test-igt.R
@@ -1,14 +1,27 @@
+data <- withr::with_seed(
+  1,
+  expand_grid(
+    id = 1:2,
+    trial = 1:80
+  ) |>
+    mutate(
+      poolid = sample(letters[1:4], n(), replace = TRUE),
+      outcome = sample(c(0, 200, 400, 2000, 4000), n(), replace = TRUE)
+    )
+)
+
 test_that("Default behavior works", {
-  data <- withr::with_seed(
-    1,
-    tibble(trial = 1:80) |>
-      mutate(
-        poolid = sample(letters[1:4], n(), replace = TRUE),
-        outcome = sample(c(0, 200, 400, 2000, 4000), n(), replace = TRUE)
-      )
-  )
   expect_snapshot_value(
-    igt(data),
-    style = "json2"
+    igt(filter(data, id == 1)),
+    style = "json2",
+    tolerance = 1e-5
+  )
+})
+
+test_that("Works with grouping variable", {
+  expect_snapshot_value(
+    igt(data, .by = "id"),
+    style = "json2",
+    tolerance = 1e-5
   )
 })

--- a/tests/testthat/test-jlo.R
+++ b/tests/testthat/test-jlo.R
@@ -1,21 +1,35 @@
+data <- withr::with_seed(
+  1,
+  expand_grid(
+    id = 1:2,
+    angle = sample(c(6:9, -(6:9)) * 6)
+  ) |>
+    rowwise() |>
+    mutate(
+      resp_base = list(sample(c(-1, 1), sample(1:100, 1), replace = TRUE)),
+      resp = recode(resp_base, `1` = "left", `-1` = "right") |>
+        stringr::str_c(collapse = "-"),
+      resp_angle = sum(resp_base) * 6,
+      resp_err = abs(resp_angle - angle) %% 360,
+      acc = ifelse(resp_err %in% c(0, 180), 1, 0)
+    ) |>
+    ungroup() |>
+    select(-contains("_"))
+)
+
 test_that("Default behavior works", {
-  data <- withr::with_seed(
-    1,
-    tibble(angle = sample(c(6:9, -(6:9)) * 6)) |>
-      rowwise() |>
-      mutate(
-        resp_base = list(sample(c(-1, 1), sample(1:100, 1), replace = TRUE)),
-        resp = recode(resp_base, `1` = "left", `-1` = "right") |>
-          stringr::str_c(collapse = "-"),
-        resp_angle = sum(resp_base) * 6,
-        resp_err = abs(resp_angle - angle) %% 360,
-        acc = ifelse(resp_err %in% c(0, 180), 1, 0)
-      ) |>
-      ungroup() |>
-      select(-contains("_"))
-  )
   expect_snapshot_value(
-    jlo(data),
-    style = "json2"
+    jlo(filter(data, id == 1)),
+    style = "json2",
+    tolerance = 1e-5
   )
 })
+
+test_that("Works with grouping variable", {
+  expect_snapshot_value(
+    jlo(data, .by = "id"),
+    style = "json2",
+    tolerance = 1e-5
+  )
+})
+

--- a/tests/testthat/test-locmem.R
+++ b/tests/testthat/test-locmem.R
@@ -1,28 +1,28 @@
-set.seed(1)
-n_users <- 5
-data <- tibble::tibble(id = rep(1:n_users, each = 10)) |>
-  rowwise() |>
-  mutate(
-    resplocdist = runif(sample.int(10, 1), 0, 10) |>
-      round(2) |>
-      stringr::str_c(collapse = "-")
+data <- withr::with_seed(
+  1,
+  expand_grid(
+    id = 1:2,
+    trial = 1:10
   ) |>
-  ungroup()
+    rowwise() |>
+    mutate(
+      resplocdist = runif(sample.int(10, 1), 0, 10) |>
+        round(2) |>
+        stringr::str_c(collapse = "-")
+    ) |>
+    ungroup()
+)
 
 test_that("Default behavior works", {
-  data <- withr::with_seed(
-    1,
-    data <- tibble(trial = 1:10) |>
-      rowwise() |>
-      mutate(
-        resplocdist = runif(sample.int(10, 1), 0, 10) |>
-          round(2) |>
-          stringr::str_c(collapse = "-")
-      ) |>
-      ungroup()
-  )
   expect_snapshot_value(
-    locmem(data),
+    locmem(filter(data, id == 1)),
+    style = "json2"
+  )
+})
+
+test_that("Works with grouping variable", {
+  expect_snapshot_value(
+    locmem(data, .by = "id"),
     style = "json2"
   )
 })

--- a/tests/testthat/test-locmem2.R
+++ b/tests/testthat/test-locmem2.R
@@ -1,20 +1,31 @@
+data <- withr::with_seed(
+  1,
+  expand_grid(
+    id = 1:2,
+    trial = 1:10
+  ) |>
+    rowwise() |>
+    mutate(
+      n_obj = sample.int(10, 1),
+      resplocdist = runif(n_obj, 0, 10) |>
+        round(2) |>
+        stringr::str_c(collapse = "-"),
+      respaccorder = sample(c(0, 1), n_obj, replace = TRUE) |>
+        stringr::str_c(collapse = "-")
+    ) |>
+    ungroup()
+)
+
 test_that("Default behavior works", {
-  data <- withr::with_seed(
-    1,
-    tibble(trial = 1:10) |>
-      rowwise() |>
-      mutate(
-        n_obj = sample.int(10, 1),
-        resplocdist = runif(n_obj, 0, 10) |>
-          round(2) |>
-          stringr::str_c(collapse = "-"),
-        respaccorder = sample(c(0, 1), n_obj, replace = TRUE) |>
-          stringr::str_c(collapse = "-")
-      ) |>
-      ungroup()
-  )
   expect_snapshot_value(
-    locmem2(data),
+    locmem2(filter(data, id == 1)),
+    style = "json2"
+  )
+})
+
+test_that("Works with grouping variable", {
+  expect_snapshot_value(
+    locmem2(data, .by = "id"),
     style = "json2"
   )
 })

--- a/tests/testthat/test-london.R
+++ b/tests/testthat/test-london.R
@@ -1,16 +1,27 @@
+data <- withr::with_seed(
+  1,
+  expand_grid(
+    id = 1:2,
+    expand_grid(minmove = 4:7, n = 4)
+  ) |>
+    uncount(n) |>
+    mutate(
+      stepsused = minmove + rbinom(n(), minmove, 0.1),
+      finished = sample(c(0, 1), n(), replace = TRUE),
+      timeinit = rexp(n(), 0.0001)
+    )
+)
+
 test_that("Default behavior works", {
-  data <- withr::with_seed(
-    1,
-    expand_grid(minmove = 4:7, n = 4) |>
-      uncount(n) |>
-      mutate(
-        stepsused = minmove + rbinom(n(), minmove, 0.1),
-        finished = sample(c(0, 1), n(), replace = TRUE),
-        timeinit = rexp(n(), 0.0001)
-      )
-  )
   expect_snapshot_value(
-    london(data),
+    london(filter(data, id == 1)),
+    style = "json2"
+  )
+})
+
+test_that("Works with grouping variable", {
+  expect_snapshot_value(
+    london(data, .by = "id"),
     style = "json2"
   )
 })

--- a/tests/testthat/test-multisense.R
+++ b/tests/testthat/test-multisense.R
@@ -1,15 +1,27 @@
-test_that("Default behavior works", {
-  data <- withr::with_seed(
-    1,
+data <- withr::with_seed(
+  1,
+  expand_grid(
+    id = 1:2,
     tibble(
       type = c("image", "sound", "mixed"),
       n = 20
-    ) |>
-      uncount(n) |>
-      mutate(rt = rexp(n(), 0.001))
-  )
+    )
+  ) |>
+    uncount(n) |>
+    mutate(rt = rexp(n(), 0.001))
+)
+
+test_that("Default behavior works", {
   expect_snapshot_value(
-    multisense(data),
+    multisense(filter(data, id == 1)),
+    style = "json2",
+    tolerance = 1e-5
+  )
+})
+
+test_that("Works with grouping variable", {
+  expect_snapshot_value(
+    multisense(data, .by = "id"),
     style = "json2",
     tolerance = 1e-5
   )

--- a/tests/testthat/test-nback.R
+++ b/tests/testthat/test-nback.R
@@ -1,18 +1,30 @@
-test_that("Default behavior works", {
-  data <- withr::with_seed(
-    1,
-    tibble::tibble(
+data <- withr::with_seed(
+  1,
+  expand_grid(
+    id = 1:2,
+    tibble(
       type = c("filler", "same", "different"),
       n = c(1, 10, 10)
-    ) |>
-      uncount(n) |>
-      mutate(
-        acc = sample(c(0, 1), n(), replace = TRUE),
-        rt = rexp(n(), 0.001)
-      )
-  )
+    )
+  ) |>
+    uncount(n) |>
+    mutate(
+      acc = sample(c(0, 1), n(), replace = TRUE),
+      rt = rexp(n(), 0.001)
+    )
+)
+
+test_that("Default behavior works", {
   expect_snapshot_value(
-    nback(data),
+    nback(filter(data, id == 1)),
+    style = "json2",
+    tolerance = 1e-5
+  )
+})
+
+test_that("Works with grouping variable", {
+  expect_snapshot_value(
+    nback(data, .by = "id"),
     style = "json2",
     tolerance = 1e-5
   )

--- a/tests/testthat/test-nle.R
+++ b/tests/testthat/test-nle.R
@@ -1,14 +1,27 @@
+data <- withr::with_seed(
+  1,
+  expand_grid(
+    id = 1:2,
+    trial = 1:20
+  ) |>
+    mutate(
+      number = sample(1:99, n(), replace = TRUE),
+      resp = sample(1:99, n(), replace = TRUE)
+    )
+)
+
 test_that("Default behavior works", {
-  data <- withr::with_seed(
-    1,
-    tibble(trial = 1:20) |>
-      mutate(
-        number = sample(1:99, n(), replace = TRUE),
-        resp = sample(1:99, n(), replace = TRUE)
-      )
-  )
   expect_snapshot_value(
-    nle(data),
-    style = "json2"
+    nle(filter(data, id == 1)),
+    style = "json2",
+    tolerance = 1e-5
+  )
+})
+
+test_that("Works with grouping variable", {
+  expect_snapshot_value(
+    nle(data, .by = "id"),
+    style = "json2",
+    tolerance = 1e-5
   )
 })

--- a/tests/testthat/test-nsymncmp.R
+++ b/tests/testthat/test-nsymncmp.R
@@ -11,8 +11,11 @@ config <- tibble::tribble(
 )
 data <- withr::with_seed(
   1,
-  config |>
-    group_by(bigsetcount, smallsetcount, pc) |>
+  expand_grid(
+    id = 1:2,
+    config
+  ) |>
+    group_by(id, bigsetcount, smallsetcount, pc) |>
     summarise(
       tibble(
         n = 10,
@@ -25,9 +28,17 @@ data <- withr::with_seed(
 
 test_that("Default behavior works", {
   expect_snapshot_value(
-    nsymncmp(data),
+    nsymncmp(filter(data, id == 1)),
     style = "json2",
     tolerance = 1e-3
+  )
+})
+
+test_that("Works with grouping variable", {
+  expect_snapshot_value(
+    nsymncmp(data, .by = "id"),
+    style = "json2",
+    tolerance = 1e-5
   )
 })
 

--- a/tests/testthat/test-nsymncmp.R
+++ b/tests/testthat/test-nsymncmp.R
@@ -38,7 +38,7 @@ test_that("Works with grouping variable", {
   expect_snapshot_value(
     nsymncmp(data, .by = "id"),
     style = "json2",
-    tolerance = 1e-5
+    tolerance = 1e-3
   )
 })
 

--- a/tests/testthat/test-racer.R
+++ b/tests/testthat/test-racer.R
@@ -1,9 +1,23 @@
-test_that("Works as expected", {
-  data <- data.frame(
+data <- expand_grid(
+  id = 1:2,
+  tibble(
     trialdur = 4000,
     escortscore = rep(0.05, 10),
     type = rep(c("target", "non-target"), each = 5),
     acc = c(rep(0, 2), rep(1, 7), 0)
   )
-  expect_snapshot_value(racer(data), style = "json2")
+)
+
+test_that("Works as expected", {
+  expect_snapshot_value(
+    racer(filter(data, id == 1)),
+    style = "json2"
+  )
+})
+
+test_that("Works with grouping variable", {
+  expect_snapshot_value(
+    racer(data, .by = "id"),
+    style = "json2"
+  )
 })

--- a/tests/testthat/test-rapm.R
+++ b/tests/testthat/test-rapm.R
@@ -1,21 +1,32 @@
-test_that("Default behavior works", {
-  data <- withr::with_seed(
-    1,
-    tibble::tibble(
+data <- withr::with_seed(
+  1,
+  expand_grid(
+    id = 1:2,
+    tibble(
       block = 1:2,
       n = c(12, 36)
-    ) |>
-      uncount(n, .id = "trial") |>
-      mutate(
-        acc = sample(
-          c(-1, 0, 1), n(),
-          replace = TRUE,
-          prob = c(0.05, 0.15, 0.8)
-        )
+    )
+  ) |>
+    uncount(n, .id = "trial") |>
+    mutate(
+      acc = sample(
+        c(-1, 0, 1), n(),
+        replace = TRUE,
+        prob = c(0.05, 0.15, 0.8)
       )
-  )
+    )
+)
+
+test_that("Default behavior works", {
   expect_snapshot_value(
-    rapm(data),
+    rapm(filter(data, id == 1)),
+    style = "json2"
+  )
+})
+
+test_that("Works with grouping variable", {
+  expect_snapshot_value(
+    rapm(data, .by = "id"),
     style = "json2"
   )
 })

--- a/tests/testthat/test-refframe.R
+++ b/tests/testthat/test-refframe.R
@@ -1,15 +1,26 @@
-test_that("Default behavior works", {
-  data <- withr::with_seed(
-    1,
+data <- withr::with_seed(
+  1,
+  expand_grid(
+    id = 1:2,
     tibble(
       type = c("Allocentric", "Egocentric"),
       n = 15
-    ) |>
-      uncount(n) |>
-      mutate(dist = runif(n(), 0, 200))
-  )
+    )
+  ) |>
+    uncount(n) |>
+    mutate(dist = runif(n(), 0, 200))
+)
+
+test_that("Default behavior works", {
   expect_snapshot_value(
-    refframe(data),
+    refframe(filter(data, id == 1)),
+    style = "json2"
+  )
+})
+
+test_that("Works with grouping variable", {
+  expect_snapshot_value(
+    refframe(data, .by = "id"),
     style = "json2"
   )
 })

--- a/tests/testthat/test-reinf.R
+++ b/tests/testthat/test-reinf.R
@@ -1,14 +1,25 @@
-test_that("Default behavior", {
-  data <- withr::with_seed(
-    1,
+data <- withr::with_seed(
+  1,
+  expand_grid(
+    id = 1:2,
     tibble(
       phase = rep(c("learn", "test"), each = 20),
       cresp = rep(letters[1:2], 20)
-    ) |>
-      mutate(acc = sample(c(0, 1), n(), replace = TRUE))
-  )
+    )
+  ) |>
+    mutate(acc = sample(c(0, 1), n(), replace = TRUE))
+)
+
+test_that("Default behavior works", {
   expect_snapshot_value(
-    reinf(data),
+    reinf(filter(data, id == 1)),
+    style = "json2"
+  )
+})
+
+test_that("Works with grouping variable", {
+  expect_snapshot_value(
+    reinf(data, .by = "id"),
     style = "json2"
   )
 })

--- a/tests/testthat/test-span.R
+++ b/tests/testthat/test-span.R
@@ -17,7 +17,11 @@
 
 data <- withr::with_seed(
   1,
-  tibble(trial = 1:14) |>
+  expand_grid(
+    id = 1:2,
+    trial = 1:14
+  ) |>
+    group_by(id) |>
     mutate(
       outcome = sample(
         c(0, 1),
@@ -48,7 +52,14 @@ data <- withr::with_seed(
 
 test_that("Default behavior works", {
   expect_snapshot_value(
-    span(data),
+    span(filter(data, id == 1)),
+    style = "json2"
+  )
+})
+
+test_that("Works with grouping variable", {
+  expect_snapshot_value(
+    span(data, .by = "id"),
     style = "json2"
   )
 })

--- a/tests/testthat/test-srt.R
+++ b/tests/testthat/test-srt.R
@@ -1,13 +1,22 @@
+data <- withr::with_seed(
+  1,
+  expand_grid(
+    id = 1:2,
+    trial = 1:10
+  ) |>
+    mutate(rt = rexp(n(), 0.001))
+)
+
 test_that("Default behavior works", {
-  data <- withr::with_seed(
-    1,
-    tibble(trial = 1:10) |>
-      mutate(
-        rt = rexp(n(), 0.001)
-      )
-  )
   expect_snapshot_value(
-    srt(data),
+    srt(filter(data, id == 1)),
+    style = "json2"
+  )
+})
+
+test_that("Works with grouping variable", {
+  expect_snapshot_value(
+    srt(data, .by = "id"),
     style = "json2"
   )
 })

--- a/tests/testthat/test-staircase.R
+++ b/tests/testthat/test-staircase.R
@@ -21,17 +21,31 @@
   }
   out
 }
-test_that("Can deal with grouping", {
-  data <- withr::with_seed(
-    1,
-    expand_grid(block = 1:3, trial = 1:20) |>
-      mutate(
-        acc = sample(c(0, 1), n(), replace = TRUE, prob = c(0.2, 0.8)),
-        level = .prepare_steps(acc, 150, 5, min = 5)
-      )
-  )
+data <- withr::with_seed(
+  1,
+  expand_grid(
+    id = 1:2,
+    block = 1:3,
+    trial = 1:20
+  ) |>
+    group_by(id) |>
+    mutate(
+      acc = sample(c(0, 1), n(), replace = TRUE, prob = c(0.2, 0.8)),
+      level = .prepare_steps(acc, 150, 5, min = 5)
+    ) |>
+    ungroup()
+)
+
+test_that("Default behavior works", {
   expect_snapshot_value(
-    staircase(data),
+    staircase(filter(data, id == 1)),
+    style = "json2"
+  )
+})
+
+test_that("Works with grouping variable", {
+  expect_snapshot_value(
+    staircase(data, .by = "id"),
     style = "json2"
   )
 })

--- a/tests/testthat/test-stopsignal.R
+++ b/tests/testthat/test-stopsignal.R
@@ -17,11 +17,11 @@
   }
   ssd
 }
-
-test_that("Default behavior works", {
-  data <- withr::with_seed(
-    1,
-    tibble::tibble(
+data <- withr::with_seed(
+  1,
+  expand_grid(
+    id = 1:2,
+    tibble(
       trial = seq_len(160),
       type = sample(
         c(
@@ -30,40 +30,50 @@ test_that("Default behavior works", {
           rep("stop2", 20)
         )
       )
-    ) |>
-      mutate(
-        acc = ifelse(
-          type == "go",
-          sample(
-            c(-1, 0, 1), n(),
-            prob = c(0.05, 0.25, 0.7),
-            replace = TRUE
-          ),
-          sample(
-            c(0, 1), n(),
-            replace = TRUE
-          )
-        )
-      ) |>
-      group_by(type) |>
-      group_modify(
-        ~ .x |>
-          mutate(
-            ssd = .prepare_ssd(
-              acc, .y$type
-            )
-          )
-      ) |>
-      ungroup() |>
-      mutate(
-        rt = ifelse(
-          (acc == 1 & type != "go") | (acc == -1 & type == "go"),
-          0, runif(n(), 150, 1000)
+    )
+  ) |>
+    mutate(
+      acc = ifelse(
+        type == "go",
+        sample(
+          c(-1, 0, 1), n(),
+          prob = c(0.05, 0.25, 0.7),
+          replace = TRUE
+        ),
+        sample(
+          c(0, 1), n(),
+          replace = TRUE
         )
       )
-  )
+    ) |>
+    group_by(id, type) |>
+    group_modify(
+      ~ .x |>
+        mutate(
+          ssd = .prepare_ssd(
+            acc, .y$type
+          )
+        )
+    ) |>
+    ungroup() |>
+    mutate(
+      rt = ifelse(
+        (acc == 1 & type != "go") | (acc == -1 & type == "go"),
+        0, runif(n(), 150, 1000)
+      )
+    )
+)
+
+test_that("Default behavior works", {
   expect_snapshot_value(
-    stopsignal(data),
+    stopsignal(filter(data, id == 1)),
+    style = "json2"
+  )
+})
+
+test_that("Works with grouping variable", {
+  expect_snapshot_value(
+    stopsignal(data, .by = "id"),
     style = "json2"
   )
 })

--- a/tests/testthat/test-sumscore.R
+++ b/tests/testthat/test-sumscore.R
@@ -1,11 +1,23 @@
+n_subject <- 2
+data <- withr::with_seed(
+  1,
+  expand_grid(
+    id = seq_len(n_subject),
+    trial = 1:10
+  ) |>
+    mutate(score = sample(1:5, n(), replace = TRUE))
+)
+
 test_that("Default behavior works", {
-  data <- withr::with_seed(
-    1,
-    tibble(trial = 1:20) |>
-      mutate(score = sample(1:5, n(), replace = TRUE))
-  )
   expect_snapshot_value(
-    sumscore(data),
+    sumscore(filter(data, id == 1)),
+    style = "json2"
+  )
+})
+
+  test_that("Works with grouping variable", {
+  expect_snapshot_value(
+    sumscore(data, .by = "id"),
     style = "json2"
   )
 })

--- a/tests/testthat/test-sumweighted.R
+++ b/tests/testthat/test-sumweighted.R
@@ -1,14 +1,24 @@
-test_that("Default behavior works", {
-  data <- withr::with_seed(
-    1,
-    expand_grid(
-      nstim = 2:4,
-      trial = 1:10
-    ) |>
-      mutate(acc = sample(-1:1, n(), replace = TRUE))
-  )
+n_subject <- 2
+data <- withr::with_seed(
+  1,
+  expand_grid(
+    id = seq_len(n_subject),
+    nstim = 2:4,
+    trial = 1:10
+  ) |>
+    mutate(acc = sample(c(0, 1), n(), replace = TRUE, prob = c(0.1, 0.9)))
+)
+
+test_that("Works as expect", {
   expect_snapshot_value(
-    sumweighted(data),
+    sumweighted(filter(data, id == 1)),
+    style = "json2"
+  )
+})
+
+test_that("Works with grouping variable", {
+  expect_snapshot_value(
+    sumweighted(data, .by = "id"),
     style = "json2"
   )
 })

--- a/tests/testthat/test-switchcost.R
+++ b/tests/testthat/test-switchcost.R
@@ -1,27 +1,37 @@
-test_that("Default behavior works", {
-  data <- withr::with_seed(
-    1,
-    expand_grid(
-      block = 1:4,
-      trial = 1:30
+data <- withr::with_seed(
+  1,
+  expand_grid(
+    id = 1:2,
+    block = 1:4,
+    trial = 1:30
+  ) |>
+    mutate(
+      task = sample(c("t1", "t2"), n(), replace = TRUE),
+      acc = sample(c(0, 1), n(), replace = TRUE),
+      rt = rexp(n(), 0.001)
     ) |>
-      mutate(
-        task = sample(c("t1", "t2"), n(), replace = TRUE),
-        acc = sample(c(0, 1), n(), replace = TRUE),
-        rt = rexp(n(), 0.001)
-      ) |>
-      mutate(
-        type = case_when(
-          trial == 1 ~ "filler",
-          task == lag(task) ~ "repeat",
-          TRUE ~ "switch"
-        )
+    mutate(
+      type = case_when(
+        trial == 1 ~ "filler",
+        task == lag(task) ~ "repeat",
+        TRUE ~ "switch"
       )
-  )
+    )
+)
+
+test_that("Default behavior works", {
   expect_snapshot_value(
-    switchcost(data),
+    switchcost(filter(data, id == 1)),
     style = "json2",
-    tolerance = 1e-3
+    tolerance = 1e-5
+  )
+})
+
+test_that("Works with grouping variable", {
+  expect_snapshot_value(
+    switchcost(data, .by = "id"),
+    style = "json2",
+    tolerance = 1e-5
   )
 })
 

--- a/tests/testthat/test-symncmp.R
+++ b/tests/testthat/test-symncmp.R
@@ -1,6 +1,7 @@
-test_that("Default behavior works", {
-  data <- withr::with_seed(
-    1,
+data <- withr::with_seed(
+  1,
+  expand_grid(
+    id = 1:2,
     tibble::tribble(
       ~big, ~small, ~n,
       2, 1, 12,
@@ -9,15 +10,25 @@ test_that("Default behavior works", {
       5, 1, 12,
       6, 1, 12,
       7, 1, 12
-    ) |>
-      uncount(n) |>
-      mutate(
-        acc = sample(c(0, 1), n(), replace = TRUE),
-        rt = rexp(n(), 0.001)
-      )
-  )
+    )
+  ) |>
+    uncount(n) |>
+    mutate(
+      acc = sample(c(0, 1), n(), replace = TRUE),
+      rt = rexp(n(), 0.001)
+    )
+)
+
+test_that("Default behavior works", {
   expect_snapshot_value(
-    symncmp(data),
+    symncmp(filter(data, id == 1)),
+    style = "json2"
+  )
+})
+
+test_that("Works with grouping variable", {
+  expect_snapshot_value(
+    symncmp(data, .by = "id"),
     style = "json2"
   )
 })

--- a/tests/testthat/test-synwin.R
+++ b/tests/testthat/test-synwin.R
@@ -1,14 +1,24 @@
+data <- withr::with_seed(
+  1,
+  expand_grid(
+    id = 1:2,
+    status = c("flip", "drag", as.character(0:10), "low", "high")
+  ) |>
+    mutate(n = sample(seq(10, 20), n(), replace = TRUE)) |>
+    uncount(n) |>
+    mutate(acc = sample(c(0, 1), n(), prob = c(0.2, 0.8), replace = TRUE))
+)
 
-test_that("Can deal with grouping", {
-  data <- withr::with_seed(
-    1,
-    tibble(status = c("flip", "drag", as.character(0:10), "low", "high")) |>
-      mutate(n = sample(seq(10, 20), n(), replace = TRUE)) |>
-      uncount(n) |>
-      mutate(acc = sample(c(0, 1), n(), prob = c(0.2, 0.8), replace = TRUE))
-  )
+test_that("Default behavior works", {
   expect_snapshot_value(
-    synwin(data),
+    synwin(filter(data, id == 1)),
+    style = "json2"
+  )
+})
+
+test_that("Works with grouping variable", {
+  expect_snapshot_value(
+    synwin(data, .by = "id"),
     style = "json2"
   )
 })


### PR DESCRIPTION
This will improve performance significantly for multiple subjects situations. What's more, after this patch, all functions will be class invariant thanks to `vctrs::vec_restore()`.

Fix #70